### PR TITLE
Add lerna bootstrap to npm postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,14 @@ This project contains the current work-in-progress Symphony Desktop Wrapper. The
 
 ## Development
 
-This project is a mono-repo, i.e. multiple distinct projects within the same git repository. This project uses [Lerna](https://github.com/lerna/lerna) to manage the dependencies between these projects and their release process.
+This project is a mono-repo, i.e. multiple distinct projects within the same Git repository. This project uses [Lerna](https://github.com/lerna/lerna) to manage the dependencies between these projects and their release process.
 
 To get started, run the following from the project root:
 
 ```
-npm install --global lerna
-lerna bootstrap
+npm install
 ```
 
-This will run `npm install` on all the sub-projects, and link any cross dependencies.
+This will install Lerna and run `lerna bootstrap`, which runs `npm install` on all the sub-projects, and links any cross dependencies.
 
 For details on how to run each sub-project, refer to their README file.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,15 @@
 {
+  "name": "ssf-desktop-wrapper",
+  "version": "0.0.0",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "lerna bootstrap"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ScottLogic/ssf-desktop-wrapper.git"
+  },
+  "homepage": "https://github.com/ScottLogic/ssf-desktop-wrapper#readme",
   "devDependencies": {
     "lerna": "2.0.0-beta.38"
   }


### PR DESCRIPTION
`lerna bootstrap` will now be automatically run after `npm install`, simplifying the setup process and removing the need for the user to install Lerna globally.