### PR TITLE
Fix API specification notification demo button click

### DIFF
--- a/packages/api-specification/src/index.html
+++ b/packages/api-specification/src/index.html
@@ -20,7 +20,7 @@
     <label>body</label>
     <input type="text" class="form-control" placeholder="body" id="body">
   </div>
-  <button id='notification-test' class="btn btn-default">Send Test Notification</button>
+  <button type="button" id='notification-test' class="btn btn-default">Send Test Notification</button>
 </form>
 
 


### PR DESCRIPTION
By default, the `type` attribute for a `<button>` is `submit`, which indicates that it submits form data to the server, and can lead to page navigation on click.

Setting the `type` to `button` indicates that the button has no default behaviour and let's us handle the button's events with our client-side code