### PR TITLE
Add live-server to API Specification

### DIFF
--- a/packages/api-specification/README.md
+++ b/packages/api-specification/README.md
@@ -4,6 +4,6 @@ This project both documents and demonstrates the Symphony Desktop Wrapper API sp
 
 ## Getting started
 
-To see the APIs in action within your browser, load `src\index.html`.
+To see the APIs in action within your browser, run `npm start`.
 
 This same code is used within the Electron and OpenFin API demonstration projects.

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -4,8 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "live-server src/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "live-server": "^1.2.0"
+  }
 }


### PR DESCRIPTION
Simplifies (slightly) viewing the documentation.