### PR TITLE
Independent window demos

### DIFF
--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -1,4 +1,7 @@
 const ipc = require('electron').ipcMain;
+const { BrowserWindow } = require('electron');
+
+let windows = [];
 
 module.exports = () => {
   const eNotify = require('electron-notify');
@@ -12,5 +15,12 @@ module.exports = () => {
       title: msg.title,
       text: msg.options.body
     });
+  });
+
+  ipc.on('ssf-new-window', (e, msg) => {
+    const newWin = new BrowserWindow();
+    newWin.loadURL(msg.url);
+    windows.push(newWin);
+    e.returnValue = newWin;
   });
 };

--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -1,7 +1,9 @@
-const ipc = require('electron').ipcMain;
-const { BrowserWindow } = require('electron');
+const {
+  BrowserWindow,
+  ipcMain: ipc
+} = require('electron');
 
-let windows = [];
+const windows = [];
 
 module.exports = () => {
   const eNotify = require('electron-notify');
@@ -18,9 +20,15 @@ module.exports = () => {
   });
 
   ipc.on('ssf-new-window', (e, msg) => {
-    const newWin = new BrowserWindow();
-    newWin.loadURL(msg.url);
-    windows.push(newWin);
-    e.returnValue = newWin;
+    const newWindow = new BrowserWindow();
+    newWindow.loadURL(msg.url);
+    windows.push(newWindow);
+    newWindow.on('close', () => {
+      const index = windows.indexOf(newWindow);
+      if (index >= 0) {
+        windows.splice(index, 1);
+      }
+    });
+    e.returnValue = newWindow;
   });
 };

--- a/packages/api-electron/preload.js
+++ b/packages/api-electron/preload.js
@@ -6,3 +6,12 @@ window.Notification = function(title, options) {
     options
   });
 };
+
+window.open = function(url, name, features) {
+  // Need to sendSync so we can return the window object, matching the HTML5 API
+  return ipc.sendSync('ssf-new-window', {
+    url,
+    name,
+    features
+  });
+};

--- a/packages/api-specification/src/index.html
+++ b/packages/api-specification/src/index.html
@@ -18,6 +18,7 @@
 <nav>
   <ul>
     <li><a href="notification-api.html">Notification</a></li>
+    <li><a href="new-window-api.html">New Window</a></li>
   </ul>
 </nav>
 

--- a/packages/api-specification/src/new-window-api-demo.js
+++ b/packages/api-specification/src/new-window-api-demo.js
@@ -2,5 +2,6 @@ var newWindowButton = document.getElementById('new-window-test');
 
 newWindowButton.onclick = function() {
   var url = document.getElementById('url').value;
-  window.open(url, 'newWin');
+  var windowName = document.getElementById('name').value;
+  window.open(url, windowName);
 };

--- a/packages/api-specification/src/new-window-api-demo.js
+++ b/packages/api-specification/src/new-window-api-demo.js
@@ -1,0 +1,6 @@
+var newWindowButton = document.getElementById('new-window-test');
+
+newWindowButton.onclick = function() {
+  var url = document.getElementById('url').value;
+  window.open(url, 'newWin');
+};

--- a/packages/api-specification/src/new-window-api.html
+++ b/packages/api-specification/src/new-window-api.html
@@ -24,6 +24,10 @@
     <label>URL</label>
     <input type="text" class="form-control" placeholder="url" id="url">
   </div>
+  <div class="form-group">
+    <label>Name</label>
+    <input type="text" class="form-control" placeholder="name" id="name">
+  </div>
   <button type="button" id='new-window-test' class="btn btn-default">Open Window</button>
 </form>
 
@@ -60,7 +64,7 @@ var newWindow = window.open(url, name, features);
 
 <dl>
   <dt>window</dt>
-  <dd>A reference to the new browser window.</dd>
+  <dd>A reference to the new window.</dd>
 </dl>
 
 <script src="new-window-api-demo.js"></script>

--- a/packages/api-specification/src/new-window-api.html
+++ b/packages/api-specification/src/new-window-api.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<title>Symphony Desktop Wrapper API Specification</title>
+<link rel='stylesheet' type='text/css' href='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css'></link>
+
+<body class='container'>
+
+<header class="page-header">
+  <nav>
+    <ul class="nav nav-pills pull-right">
+      <li><a href="index.html">Index</a></li>
+    </ul>
+  </nav>
+  <h1>Symphony Desktop Wrapper API Demo</h1>
+</header>
+
+<h2>New Window API</h2>
+
+<h3>Try me</h3>
+
+<form class="form-inline">
+  <div class="form-group">
+    <label>URL</label>
+    <input type="text" class="form-control" placeholder="url" id="url">
+  </div>
+  <button type="button" id='new-window-test' class="btn btn-default">Open Window</button>
+</form>
+
+<h3>Overview</h3>
+
+<p>The window API is used to create a new browser window. <a href='https://developer.mozilla.org/en-US/docs/Web/API/Window/open'>HTML5 Window API</a></p>
+
+<h3>Method Signature</h3>
+
+<pre>
+window.open(url, name, features)
+</pre>
+
+<p>Creates a new window.</p>
+
+<h4>Syntax</h4>
+
+<pre>
+var newWindow = window.open(url, name, features);
+</pre>
+
+<h4>Parameters</h4>
+
+<dl>
+  <dt>url</dt>
+  <dd>URL to open in the window. Must be prefixed with the protocol (i.e. http://)</dd>
+  <dt>name</dt>
+  <dd>Name of the new window. Should not contain whitespace</dd>
+  <dt>features (optional)</dt>
+  <dd>DOMString to set features of the new window</dd>
+</dl>
+
+<h4>Return Value</h4>
+
+<dl>
+  <dt>window</dt>
+  <dd>A reference to the new browser window.</dd>
+</dl>
+
+<script src="new-window-api-demo.js"></script>
+</body>

--- a/packages/api-specification/src/new-window-api.html
+++ b/packages/api-specification/src/new-window-api.html
@@ -41,7 +41,7 @@
 window.open(url, name, features)
 </pre>
 
-<p>Creates a new window.</p>
+<p>Creates a new window. If a window with the same name already exists, that window will be reused.</p>
 
 <h4>Syntax</h4>
 

--- a/packages/api-specification/src/new-window-api.html
+++ b/packages/api-specification/src/new-window-api.html
@@ -42,6 +42,7 @@ window.open(url, name, features)
 </pre>
 
 <p>Creates a new window. If a window with the same name already exists, that window will be reused.</p>
+<p>Note: Window resuse is platform dependant. The API is <a href='https://developer.mozilla.org/en-US/docs/Web/API/Window/open'>inconsistent between browsers</a> and Electron only allows this for windows created via the built in <code>window.open()</code> method (child windows), not <code>new BrowserWindow()</code> that is used to implement this API.</p>
 
 <h4>Syntax</h4>
 


### PR DESCRIPTION
Fully independent windows in both OpenFin and Electron use the HTML5 API. This is a demo to showcase that functionality. 

**Note:** Reopening a window with the same name parameter does not work in Electron when not using `window.open`, but this method has the side effect of creating a child window (i.e. the new window closes when the parent closes). It also does not work in OpenFin, and is [inconsistent across browsers](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) (See note about strWindowName). For this reason, we decided that having a fully independent window was more important, but it should be possible to add this functionality in manually at a later date.