### PR TITLE
Order index links in alphabetical order

### DIFF
--- a/packages/api-specification/src/index.html
+++ b/packages/api-specification/src/index.html
@@ -19,10 +19,10 @@
   <nav>
     <ul>
       <li><a href="app-api.html">App</a></li>
-      <li><a href="notification-api.html">Notification</a></li>
-      <li><a href="new-window-api.html">New Window</a></li>
-      <li><a href="screen-snippet-api.html">Screen Snippet</a></li>
       <li><a href="messaging-api.html">Messaging</a></li>
+      <li><a href="new-window-api.html">New Window</a></li>
+      <li><a href="notification-api.html">Notification</a></li>
+      <li><a href="screen-snippet-api.html">Screen Snippet</a></li>
     </ul>
   </nav>
 </div>


### PR DESCRIPTION
Order links in `index.html` alphabetically. Makes it easier to find the correct demo.