### PR TITLE
Add Browser window messaging

### DIFF
--- a/packages/api-browser/app.js
+++ b/packages/api-browser/app.js
@@ -7,3 +7,13 @@ if (!window.ssf.app) {
 }
 
 window.ssf.app.ready = () => Promise.resolve();
+
+window.accessibleWindows = {};
+
+// if we have an opener, we are not the parent so we need to add it as a window
+if (window.opener) {
+  // The reference to the opener is not the full window object, so there is no onclose handler available
+  window.accessibleWindows['parent'] = window.opener;
+} else {
+  window.name = 'parent';
+}

--- a/packages/api-browser/message.js
+++ b/packages/api-browser/message.js
@@ -1,0 +1,29 @@
+if (!window.ssf) {
+  window.ssf = {};
+}
+
+class MessageService {
+  static send(windowId, topic, message) {
+    const win = window.accessableWindows.find((w) => w.id.toString() === windowId);
+    const senderId = window.ssf.Window.getCurrentWindowId();
+    if (win) {
+      win.window.postMessage({
+        senderId,
+        topic,
+        message
+      }, '*');
+    }
+  }
+
+  static subscribe(windowId, topic, listener) {
+    const receiveMessage = (event) => {
+      if ((windowId === '*' || windowId === event.data.senderId) && topic === event.data.topic) {
+        listener(event.data.message, event.data.senderId);
+      }
+    };
+
+    window.addEventListener('message', receiveMessage, false);
+  }
+}
+
+window.ssf.MessageService = MessageService;

--- a/packages/api-browser/message.js
+++ b/packages/api-browser/message.js
@@ -4,7 +4,7 @@ if (!window.ssf) {
 
 class MessageService {
   static send(windowId, topic, message) {
-    const win = window.accessableWindows.find((w) => w.id.toString() === windowId);
+    const win = window.accessibleWindows[windowId];
     const senderId = window.ssf.Window.getCurrentWindowId();
     if (win) {
       win.window.postMessage({

--- a/packages/api-browser/window.js
+++ b/packages/api-browser/window.js
@@ -2,15 +2,14 @@ if (!window.ssf) {
   window.ssf = {};
 }
 
-window.accessableWindows = [];
-
 class Window {
   constructor(url, name, features) {
     const win = window.open(url, name, objectToFeaturesString(features));
-    window.accessableWindows.push({
-      id: name,
-      window: win
-    });
+    win.onclose = () => {
+      window.accessibleWindows[win.name] = null;
+    };
+
+    window.accessibleWindows[name] = win;
   }
 
   static getCurrentWindowId() {
@@ -32,15 +31,5 @@ const objectToFeaturesString = (features) => {
     return `${key}=${value}`;
   }).join(',');
 };
-
-// if we have an opener, we are not the parent so we need to add it as a window
-if (window.opener) {
-  window.accessableWindows.push({
-    id: 'parent',
-    window: window.opener
-  });
-} else {
-  window.name = 'parent';
-}
 
 window.ssf.Window = Window;

--- a/packages/api-browser/window.js
+++ b/packages/api-browser/window.js
@@ -2,10 +2,20 @@ if (!window.ssf) {
   window.ssf = {};
 }
 
+window.accessableWindows = [];
+
 class Window {
   constructor(url, name, features) {
-    window.open(url, name, objectToFeaturesString(features));
+    const win = window.open(url, name, objectToFeaturesString(features));
+    window.accessableWindows.push({
+      id: name,
+      window: win
+    });
   }
+
+  static getCurrentWindowId() {
+    return window.name;
+  };
 }
 
 const objectToFeaturesString = (features) => {
@@ -22,5 +32,15 @@ const objectToFeaturesString = (features) => {
     return `${key}=${value}`;
   }).join(',');
 };
+
+// if we have an opener, we are not the parent so we need to add it as a window
+if (window.opener) {
+  window.accessableWindows.push({
+    id: 'parent',
+    window: window.opener
+  });
+} else {
+  window.name = 'parent';
+}
 
 window.ssf.Window = Window;

--- a/packages/api-specification/src/messaging-api-test-window.html
+++ b/packages/api-specification/src/messaging-api-test-window.html
@@ -47,6 +47,7 @@
 
   <hr/>
 
+  <script src="app.js"></script>
   <script src="message.js"></script>
   <script src="window.js"></script>
 


### PR DESCRIPTION
Browser window messaging is more limited than in Electron or OpenFin due to the lack of main process. The current implementation uses `window.postMessage()`, but this requires a reference to the window you wish to send the message. Therefore, only windows that have been created by `window.open` can be sent messages (as well as the window which opened the current window via `window.opener`).

To keep the browser API in line with the other APIs, new windows are stored with their name in a global object, which can be referenced via an id (the window name, or 'parent' for the opener window). 