### PR TITLE
Window api extension

### DIFF
--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -4,22 +4,23 @@ import {
 } from './accessible-windows';
 
 class Window {
-  constructor(url, name, features) {
-    const win = window.open(url, name, objectToFeaturesString(features));
-    win.onclose = () => {
-      removeAccessibleWindow(win.name);
-    };
+  constructor(...args) {
+    if (args.length === 0) {
+      this.innerWindow = window;
+    } else {
+      const [url, name, features] = args;
 
-    addAccessibleWindow(name, win);
-    this.innerWindow = window.open(url, name, objectToFeaturesString(features));
-    this.innerWindow.onclose = () => {
-      window.accessibleWindows[this.innerWindow.name] = null;
-    };
+      this.innerWindow = window.open(url, name, objectToFeaturesString(features));
+      this.innerWindow.onclose = () => {
+        removeAccessibleWindow(this.innerWindow.name);
+      };
 
-    window.accessibleWindows[name] = this.innerWindow;
+      addAccessibleWindow(name, this.innerWindow);
+    }
   }
 
   close() {
+    // Close only works on windows that were opened by the current window
     if (this.innerWindow) {
       this.innerWindow.close();
     }
@@ -36,6 +37,10 @@ class Window {
   static getCurrentWindowId() {
     return window.name;
   };
+
+  static getCurrentWindow() {
+    return new window.ssf.Window();
+  }
 }
 
 const objectToFeaturesString = (features) => {

--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -39,7 +39,7 @@ class Window {
   };
 
   static getCurrentWindow() {
-    return new window.ssf.Window();
+    return new Window();
   }
 }
 

--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -3,6 +3,8 @@ import {
   removeAccessibleWindow
 } from './accessible-windows';
 
+let currentWindow = null;
+
 class Window {
   constructor(...args) {
     if (args.length === 0) {
@@ -51,7 +53,12 @@ class Window {
   };
 
   static getCurrentWindow() {
-    return new Window();
+    if (currentWindow) {
+      return currentWindow;
+    }
+
+    currentWindow = new Window();
+    return currentWindow;
   }
 }
 

--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -34,6 +34,18 @@ class Window {
     // Unable to 'hide' browser window
   }
 
+  focus() {
+    if (this.innerWindow) {
+      this.innerWindow.focus();
+    }
+  }
+
+  blur() {
+    if (this.innerWindow) {
+      this.innerWindow.blur();
+    }
+  }
+
   static getCurrentWindowId() {
     return window.name;
   };

--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -11,6 +11,26 @@ class Window {
     };
 
     addAccessibleWindow(name, win);
+    this.innerWindow = window.open(url, name, objectToFeaturesString(features));
+    this.innerWindow.onclose = () => {
+      window.accessibleWindows[this.innerWindow.name] = null;
+    };
+
+    window.accessibleWindows[name] = this.innerWindow;
+  }
+
+  close() {
+    if (this.innerWindow) {
+      this.innerWindow.close();
+    }
+  }
+
+  show() {
+    // Unable to 'show' browser window
+  }
+
+  hide() {
+    // Unable to 'hide' browser window
   }
 
   static getCurrentWindowId() {

--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -112,40 +112,31 @@ ipc.on('ssf-get-window-id', (e) => {
 });
 
 ipc.on('ssf-close-window', (e, id) => {
-  const win = BrowserWindow.fromId(id);
-  // Don't need to remove the window from the windows array, the onclose event does that for us
-  if (win) {
-    win.close();
-  }
+  getWindowFromId(id, (win) => win.close());
 });
 
 ipc.on('ssf-show-window', (e, id) => {
-  const win = BrowserWindow.fromId(id);
-  if (win) {
-    win.show();
-  }
+  getWindowFromId(id, (win) => win.show());
 });
 
 ipc.on('ssf-hide-window', (e, id) => {
-  const win = BrowserWindow.fromId(id);
-  if (win) {
-    win.hide();
-  }
+  getWindowFromId(id, (win) => win.hide());
 });
 
 ipc.on('ssf-focus-window', (e, id) => {
-  const win = BrowserWindow.fromId(id);
-  if (win) {
-    win.focus();
-  }
+  getWindowFromId(id, (win) => win.focus());
 });
 
 ipc.on('ssf-blur-window', (e, id) => {
+  getWindowFromId(id, (win) => win.blur());
+});
+
+const getWindowFromId = (id, cb) => {
   const win = BrowserWindow.fromId(id);
   if (win) {
-    win.blur();
+    cb(win);
   }
-});
+};
 
 module.exports.app = {
   ready

--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -108,7 +108,7 @@ const ready = (cb) => {
 };
 
 ipc.on('ssf-get-window-id', (e) => {
-  e.returnValue = BrowserWindow.fromWebContents(e.sender);
+  e.returnValue = BrowserWindow.fromWebContents(e.sender).id;
 });
 
 ipc.on('ssf-close-window', (e, id) => {

--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -79,32 +79,6 @@ module.exports = (url) => {
     destinationWindow.webContents.send(`ssf-send-message-*`, msg.message, senderId);
   });
 
-  ipc.on('ssf-get-window-id', (e) => {
-    e.returnValue = e.sender.id;
-  });
-
-  ipc.on('ssf-close-window', (e, id) => {
-    const win = BrowserWindow.fromId(id);
-    // Don't need to remove the window from the windows array, the onclose event does that for us
-    if (win) {
-      win.close();
-    }
-  });
-
-  ipc.on('ssf-show-window', (e, id) => {
-    const win = BrowserWindow.fromId(id);
-    if (win) {
-      win.show();
-    }
-  });
-
-  ipc.on('ssf-hide-window', (e, id) => {
-    const win = BrowserWindow.fromId(id);
-    if (win) {
-      win.hide();
-    }
-  });
-
   createInitialHiddenWindow(url);
 };
 
@@ -132,6 +106,46 @@ const createInitialHiddenWindow = (url) => {
 const ready = (cb) => {
   app.on('ready', cb);
 };
+
+ipc.on('ssf-get-window-id', (e) => {
+  e.returnValue = BrowserWindow.fromWebContents(e.sender);
+});
+
+ipc.on('ssf-close-window', (e, id) => {
+  const win = BrowserWindow.fromId(id);
+  // Don't need to remove the window from the windows array, the onclose event does that for us
+  if (win) {
+    win.close();
+  }
+});
+
+ipc.on('ssf-show-window', (e, id) => {
+  const win = BrowserWindow.fromId(id);
+  if (win) {
+    win.show();
+  }
+});
+
+ipc.on('ssf-hide-window', (e, id) => {
+  const win = BrowserWindow.fromId(id);
+  if (win) {
+    win.hide();
+  }
+});
+
+ipc.on('ssf-focus-window', (e, id) => {
+  const win = BrowserWindow.fromId(id);
+  if (win) {
+    win.focus();
+  }
+});
+
+ipc.on('ssf-blur-window', (e, id) => {
+  const win = BrowserWindow.fromId(id);
+  if (win) {
+    win.blur();
+  }
+});
 
 module.exports.app = {
   ready

--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -45,7 +45,10 @@ module.exports = (url) => {
       }
     });
 
-    e.returnValue = newWindow;
+    e.returnValue = {
+      id: newWindow.id
+    };
+
     windows.push(newWindow);
   });
 
@@ -78,6 +81,28 @@ module.exports = (url) => {
 
   ipc.on('ssf-get-window-id', (e) => {
     e.returnValue = e.sender.id;
+  });
+
+  ipc.on('ssf-close-window', (e, id) => {
+    const win = BrowserWindow.fromId(id);
+    // Don't need to remove the window from the windows array, the onclose event does that for us
+    if (win) {
+      win.close();
+    }
+  });
+
+  ipc.on('ssf-show-window', (e, id) => {
+    const win = BrowserWindow.fromId(id);
+    if (win) {
+      win.show();
+    }
+  });
+
+  ipc.on('ssf-hide-window', (e, id) => {
+    const win = BrowserWindow.fromId(id);
+    if (win) {
+      win.hide();
+    }
   });
 
   createInitialHiddenWindow(url);

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -1,12 +1,20 @@
 const ipc = require('electron').ipcRenderer;
 
 class Window {
-  constructor(url, name, features) {
-    this.innerWindow = ipc.sendSync('ssf-new-window', {
-      url,
-      name,
-      features
-    });
+  constructor(...args) {
+    if (args.length === 0) {
+      this.innerWindow = {
+        id: window.ssf.Window.getCurrentWindowId()
+      };
+    } else {
+      const [url, name, features] = args;
+
+      this.innerWindow = ipc.sendSync('ssf-new-window', {
+        url,
+        name,
+        features
+      });
+    }
   }
 
   close() {
@@ -23,6 +31,10 @@ class Window {
 
   static getCurrentWindowId() {
     return ipc.sendSync('ssf-get-window-id');
+  }
+
+  static getCurrentWindow() {
+    return new window.ssf.Window();
   }
 }
 

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -2,23 +2,23 @@ const ipc = require('electron').ipcRenderer;
 
 class Window {
   constructor(url, name, features) {
-    this.id = ipc.sendSync('ssf-new-window', {
+    this.innerWindow = ipc.sendSync('ssf-new-window', {
       url,
       name,
       features
-    }).id;
+    });
   }
 
   close() {
-    ipc.send('ssf-close-window', this.id);
+    ipc.send('ssf-close-window', this.innerWindow.id);
   }
 
   show() {
-    ipc.send('ssf-show-window', this.id);
+    ipc.send('ssf-show-window', this.innerWindow.id);
   }
 
   hide() {
-    ipc.send('ssf-hide-window', this.id);
+    ipc.send('ssf-hide-window', this.innerWindow.id);
   }
 
   static getCurrentWindowId() {

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -29,6 +29,14 @@ class Window {
     ipc.send('ssf-hide-window', this.innerWindow.id);
   }
 
+  focus() {
+    ipc.send('ssf-focus-window', this.innerWindow.id);
+  }
+
+  blur() {
+    ipc.send('ssf-blur-window', this.innerWindow.id);
+  }
+
   static getCurrentWindowId() {
     return ipc.sendSync('ssf-get-window-id');
   }

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -34,7 +34,7 @@ class Window {
   }
 
   static getCurrentWindow() {
-    return new window.ssf.Window();
+    return new Window();
   }
 }
 

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -2,11 +2,23 @@ const ipc = require('electron').ipcRenderer;
 
 class Window {
   constructor(url, name, features) {
-    return ipc.sendSync('ssf-new-window', {
+    this.id = ipc.sendSync('ssf-new-window', {
       url,
       name,
       features
-    });
+    }).id;
+  }
+
+  close() {
+    ipc.send('ssf-close-window', this.id);
+  }
+
+  show() {
+    ipc.send('ssf-show-window', this.id);
+  }
+
+  hide() {
+    ipc.send('ssf-hide-window', this.id);
   }
 
   static getCurrentWindowId() {

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -18,23 +18,27 @@ class Window {
   }
 
   close() {
-    ipc.send('ssf-close-window', this.innerWindow.id);
+    this.sendWindowAction('ssf-close-window');
   }
 
   show() {
-    ipc.send('ssf-show-window', this.innerWindow.id);
+    this.sendWindowAction('ssf-show-window');
   }
 
   hide() {
-    ipc.send('ssf-hide-window', this.innerWindow.id);
+    this.sendWindowAction('ssf-hide-window');
   }
 
   focus() {
-    ipc.send('ssf-focus-window', this.innerWindow.id);
+    this.sendWindowAction('ssf-focus-window');
   }
 
   blur() {
-    ipc.send('ssf-blur-window', this.innerWindow.id);
+    this.sendWindowAction('ssf-blur-window');
+  }
+
+  sendWindowAction(action) {
+    ipc.send(action, this.innerWindow.id);
   }
 
   static getCurrentWindowId() {

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -1,5 +1,7 @@
 const ipc = require('electron').ipcRenderer;
 
+let currentWindow = null;
+
 class Window {
   constructor(...args) {
     if (args.length === 0) {
@@ -46,7 +48,12 @@ class Window {
   }
 
   static getCurrentWindow() {
-    return new Window();
+    if (currentWindow) {
+      return currentWindow;
+    }
+
+    currentWindow = new Window();
+    return currentWindow;
   }
 }
 

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -1,32 +1,37 @@
 class Window {
-  constructor(url, name, features) {
-    let newWindow;
-    const handleError = (error) => console.error('Error creating window: ' + error);
-
-    if (features && features.child) {
-      newWindow = new fin.desktop.Window({
-        name,
-        url
-      }, () => newWindow.show(), handleError);
+  constructor(...args) {
+    if (args.length === 0) {
+      this.innerWindow = fin.desktop.Window.getCurrent();
     } else {
-      // UUID must be the same as name
-      const uuid = name;
-      const mainWindowOptions = {
-        autoShow: true
-      };
+      const [url, name, features] = args;
 
-      const app = new fin.desktop.Application({
-        name,
-        url,
-        uuid,
-        mainWindowOptions
-      }, () => app.run(), handleError);
+      let newWindow;
+      const handleError = (error) => console.error('Error creating window: ' + error);
 
-      // Need to return the window object, not the application
-      newWindow = app.getWindow();
+      if (features && features.child) {
+        newWindow = new fin.desktop.Window({
+          name,
+          url
+        }, () => newWindow.show(), handleError);
+      } else {
+        // UUID must be the same as name
+        const uuid = name;
+        const mainWindowOptions = {
+          autoShow: true
+        };
+
+        const app = new fin.desktop.Application({
+          name,
+          url,
+          uuid,
+          mainWindowOptions
+        }, () => app.run(), handleError);
+
+        // Need to return the window object, not the application
+        newWindow = app.getWindow();
+      }
+      this.innerWindow = newWindow;
     }
-
-    this.innerWindow = newWindow;
   }
 
   close() {
@@ -44,6 +49,10 @@ class Window {
   static getCurrentWindowId() {
     const currentWin = fin.desktop.Window.getCurrent();
     return `${currentWin.uuid}:${currentWin.name}`;
+  }
+
+  static getCurrentWindow() {
+    return new window.ssf.Window();
   }
 }
 

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -26,7 +26,19 @@ class Window {
       newWindow = app.getWindow();
     }
 
-    return newWindow;
+    this.innerWindow = newWindow;
+  }
+
+  close() {
+    this.innerWindow.close();
+  }
+
+  hide() {
+    this.innerWindow.hide();
+  }
+
+  show() {
+    this.innerWindow.show();
   }
 
   static getCurrentWindowId() {

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -1,3 +1,5 @@
+let currentWindow = null;
+
 class Window {
   constructor(...args) {
     if (args.length === 0) {
@@ -60,7 +62,12 @@ class Window {
   }
 
   static getCurrentWindow() {
-    return new Window();
+    if (currentWindow) {
+      return currentWindow;
+    }
+
+    currentWindow = new Window();
+    return currentWindow;
   }
 }
 

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -52,7 +52,7 @@ class Window {
   }
 
   static getCurrentWindow() {
-    return new window.ssf.Window();
+    return new Window();
   }
 }
 

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -46,6 +46,14 @@ class Window {
     this.innerWindow.show();
   }
 
+  focus() {
+    this.innerWindow.focus();
+  }
+
+  blur() {
+    this.innerWindow.blur();
+  }
+
   static getCurrentWindowId() {
     const currentWin = fin.desktop.Window.getCurrent();
     return `${currentWin.uuid}:${currentWin.name}`;

--- a/packages/api-specification/src/messaging-api-demo.js
+++ b/packages/api-specification/src/messaging-api-demo.js
@@ -4,27 +4,27 @@ const newWindowButton = document.getElementById('new-window');
 
 const appReady = ssf.app.ready();
 
-const windowDetailsId = document.getElementById('window-uuid');
-windowDetailsId.innerText = ssf.Window.getCurrentWindowId();
+appReady.then(() => {
+  const windowDetailsId = document.getElementById('window-uuid');
+  windowDetailsId.innerText = ssf.Window.getCurrentWindowId();
 
-newWindowButton.onclick = () => {
-  // Create a random hex string as the window name
-  const id = (((1 + Math.random()) * 0x1000000) | 0).toString(16).substring(1);
+  newWindowButton.onclick = () => {
+    // Create a random hex string as the window name
+    const id = (((1 + Math.random()) * 0x1000000) | 0).toString(16).substring(1);
 
-  const isChild = document.getElementById('child').checked ? 'yes' : 'no';
+    const isChild = document.getElementById('child').checked ? 'yes' : 'no';
 
-  appReady.then(() => {
     // eslint-disable-next-line no-new
     new ssf.Window(`http://localhost:${location.port}/messaging-api-test-window.html`, id, 'child=' + isChild);
 
     ssf.MessageService.subscribe('*', 'test', (message, senderId) => {
       messageBox.innerText = '\'' + message + '\' from ' + senderId;
     });
-  });
-};
+  };
 
-sendButton.onclick = () => {
-  const uuid = document.getElementById('uuid').value;
-  const message = document.getElementById('message').value;
-  ssf.MessageService.send(uuid, 'test', message);
-};
+  sendButton.onclick = () => {
+    const uuid = document.getElementById('uuid').value;
+    const message = document.getElementById('message').value;
+    ssf.MessageService.send(uuid, 'test', message);
+  };
+});

--- a/packages/api-specification/src/window-api-demo.js
+++ b/packages/api-specification/src/window-api-demo.js
@@ -16,17 +16,31 @@ newWindowButton.onclick = function() {
 };
 
 var closeWindow = document.getElementById('close-window');
-var hideWindow = document.getElementById('hide-window');
-var showWindow = document.getElementById('show-window');
 
-closeWindow.onclick = function() {
+closeWindow.onclick = () => {
   win.close();
 };
 
-hideWindow.onclick = function() {
+var hideWindow = document.getElementById('hide-window');
+
+hideWindow.onclick = () => {
   win.hide();
 };
 
-showWindow.onclick = function() {
+var showWindow = document.getElementById('show-window');
+
+showWindow.onclick = () => {
   win.show();
+};
+
+var focusWindow = document.getElementById('focus-window');
+
+focusWindow.onclick = () => {
+  win.focus();
+};
+
+var blurWindow = document.getElementById('blur-window');
+
+blurWindow.onclick = () => {
+  win.blur();
 };

--- a/packages/api-specification/src/window-api-demo.js
+++ b/packages/api-specification/src/window-api-demo.js
@@ -4,43 +4,43 @@ const appReady = ssf.app.ready();
 
 let win;
 
-newWindowButton.onclick = function() {
-  var url = document.getElementById('url').value;
-  var windowName = document.getElementById('name').value;
-  var isChild = document.getElementById('child').checked;
-  appReady.then(() => {
+appReady.then(() => {
+  newWindowButton.onclick = function() {
+    var url = document.getElementById('url').value;
+    var windowName = document.getElementById('name').value;
+    var isChild = document.getElementById('child').checked;
     win = new ssf.Window(url, windowName, {
       child: isChild
     });
-  });
-};
+  };
 
-var closeWindow = document.getElementById('close-window');
+  var closeWindow = document.getElementById('close-window');
 
-closeWindow.onclick = () => {
-  win.close();
-};
+  closeWindow.onclick = () => {
+    win.close();
+  };
 
-var hideWindow = document.getElementById('hide-window');
+  var hideWindow = document.getElementById('hide-window');
 
-hideWindow.onclick = () => {
-  win.hide();
-};
+  hideWindow.onclick = () => {
+    win.hide();
+  };
 
-var showWindow = document.getElementById('show-window');
+  var showWindow = document.getElementById('show-window');
 
-showWindow.onclick = () => {
-  win.show();
-};
+  showWindow.onclick = () => {
+    win.show();
+  };
 
-var focusWindow = document.getElementById('focus-window');
+  var focusWindow = document.getElementById('focus-window');
 
-focusWindow.onclick = () => {
-  win.focus();
-};
+  focusWindow.onclick = () => {
+    win.focus();
+  };
 
-var blurWindow = document.getElementById('blur-window');
+  var blurWindow = document.getElementById('blur-window');
 
-blurWindow.onclick = () => {
-  win.blur();
-};
+  blurWindow.onclick = () => {
+    win.blur();
+  };
+});

--- a/packages/api-specification/src/window-api-demo.js
+++ b/packages/api-specification/src/window-api-demo.js
@@ -2,14 +2,31 @@ var newWindowButton = document.getElementById('new-window-test');
 
 const appReady = ssf.app.ready();
 
+let win;
+
 newWindowButton.onclick = function() {
   var url = document.getElementById('url').value;
   var windowName = document.getElementById('name').value;
   var isChild = document.getElementById('child').checked;
   appReady.then(() => {
-    // eslint-disable-next-line no-new
-    new ssf.Window(url, windowName, {
+    win = new ssf.Window(url, windowName, {
       child: isChild
     });
   });
+};
+
+var closeWindow = document.getElementById('close-window');
+var hideWindow = document.getElementById('hide-window');
+var showWindow = document.getElementById('show-window');
+
+closeWindow.onclick = function() {
+  win.close();
+};
+
+hideWindow.onclick = function() {
+  win.hide();
+};
+
+showWindow.onclick = function() {
+  win.show();
 };

--- a/packages/api-specification/src/window-api.html
+++ b/packages/api-specification/src/window-api.html
@@ -45,6 +45,8 @@
     <button id="close-window" type="button" class="btn btn-default">Close</button>
     <button id="show-window" type="button" class="btn btn-default">Show</button>
     <button id="hide-window" type="button" class="btn btn-default">Hide</button>
+    <button id="focus-window" type="button" class="btn btn-default">Focus</button>
+    <button id="blur-window" type="button" class="btn btn-default">Blur</button>
   </form>
 
   <h3>Overview</h3>

--- a/packages/api-specification/src/window-api.html
+++ b/packages/api-specification/src/window-api.html
@@ -56,6 +56,12 @@
   <h3>Constructor</h3>
 
   <pre>
+  new ssf.Window()
+  </pre>
+
+  <p>Creates a new window object for the current window.</p>
+
+  <pre>
   new ssf.Window(url, name, features)
   </pre>
 
@@ -91,14 +97,16 @@
     <dd>A reference to the new window.</dd>
   </dl>
 
-  <h3>Methods</h3>
-  <h5>Static</h5>
+  <h5>Static Methods</h5>
   <ul>
-    <li><code>getCurrentWindowId()</code> (static) - Get the current window id as a string</li>
+    <li><code>getCurrentWindow()</code> - Get the current window object</li>
+    <li><code>getCurrentWindowId()</code> - Get the current window id as a string</li>
   </ul>
-  <h5>Instance</h5>
+  <h5>Class Methods</h5>
   <ul>
+    <li><code>blur()</code> - Remove focus from the window</li>
     <li><code>close()</code> - Close the window</li>
+    <li><code>focus()</code> - Give the window focus</li>
     <li><code>hide()</code> - Hide a visible window (Non browser only)</li>
     <li><code>show()</code> - Show a hidden window (Non browser only)</li>
   </ul>

--- a/packages/api-specification/src/window-api.html
+++ b/packages/api-specification/src/window-api.html
@@ -56,17 +56,16 @@
   <h3>Constructor</h3>
 
   <pre>
-  new ssf.Window()
-  </pre>
-
-  <p>Creates a new window object for the current window.</p>
-
-  <pre>
   new ssf.Window(url, name, features)
   </pre>
 
   <p>Creates a new window. If a window with the same name already exists, that window will be reused.</p>
   <p><i>Note:</i> Window resuse is platform dependant. The API is <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/open">inconsistent between browsers</a> and Electron only allows this for windows created via the built in <code>window.open()</code> method (child windows), not <code>new BrowserWindow()</code> that is used to implement this API.</p>
+
+  <p><b>To get the current window object, use:</b></p>
+  <pre>
+  ssf.Window.getCurrentWindow()
+  </pre>
 
   <h4>Syntax</h4>
 

--- a/packages/api-specification/src/window-api.html
+++ b/packages/api-specification/src/window-api.html
@@ -90,8 +90,15 @@
   </dl>
 
   <h3>Methods</h3>
+  <h5>Static</h5>
   <ul>
     <li><code>getCurrentWindowId()</code> (static) - Get the current window id as a string</li>
+  </ul>
+  <h5>Instance</h5>
+  <ul>
+    <li><code>close()</code> - Close the window</li>
+    <li><code>hide()</code> - Hide a visible window (Non browser only)</li>
+    <li><code>show()</code> - Show a hidden window (Non browser only)</li>
   </ul>
 </div>
 

--- a/packages/api-specification/src/window-api.html
+++ b/packages/api-specification/src/window-api.html
@@ -38,6 +38,15 @@
     <button type="button" id="new-window-test" class="btn btn-default">Open Window</button>
   </form>
 
+  <hr/>
+
+  <h4>New window controls</h4>
+  <form class="form-inline">
+    <button id="close-window" type="button" class="btn btn-default">Close</button>
+    <button id="show-window" type="button" class="btn btn-default">Show</button>
+    <button id="hide-window" type="button" class="btn btn-default">Hide</button>
+  </form>
+
   <h3>Overview</h3>
 
   <p>The Window API is used to create a new browser window.</p>


### PR DESCRIPTION
Added new methods to the window API:
* Close
* Show (Does not work for browser)
* Hide (Does not work for browser)
* Focus
* Blur

As well as being able to get the current window object by passing no parameters to the constructor (i.e. `new ssf.Window()` returns the current window object) or calling `ssf.Window.getCurrentWindow()`. For the browser, close also only works on windows that were opened via `window.open` (i.e. the window cannot close itself or its parents).