### PR TITLE
Message service unsubscribe

### DIFF
--- a/packages/api-browser/src/message-service.js
+++ b/packages/api-browser/src/message-service.js
@@ -35,7 +35,7 @@ class MessageService {
   static unsubscribe(windowId, topic, listener) {
     let deleteKey = null;
 
-    // We cant use listenerMap.has() here becuase reconsrtucting the key from the arguments is a different object
+    // We cant use listenerMap.has() here because reconstructing the key from the arguments is a different object
     // i.e. {} !== {}
     listenerMap.forEach((value, key) => {
       if (key.windowId === windowId && key.topic === topic && key.listener === listener) {

--- a/packages/api-browser/src/message-service.js
+++ b/packages/api-browser/src/message-service.js
@@ -1,5 +1,7 @@
 import { getAccessibleWindow } from './accessible-windows';
 
+const listenerMap = new Map();
+
 class MessageService {
   static send(windowId, topic, message) {
     const win = getAccessibleWindow(windowId);
@@ -21,6 +23,28 @@ class MessageService {
     };
 
     window.addEventListener('message', receiveMessage, false);
+
+    // Map the arguments to the actual listener that was added
+    listenerMap.set({
+      windowId,
+      topic,
+      listener
+    }, receiveMessage);
+  }
+
+  static unsubscribe(windowId, topic, listener) {
+    let deleteKey = null;
+
+    // We cant use listenerMap.has() here becuase reconsrtucting the key from the arguments is a different object
+    // i.e. {} !== {}
+    listenerMap.forEach((value, key) => {
+      if (key.windowId === windowId && key.topic === topic && key.listener === listener) {
+        window.removeEventListener('message', listener);
+        deleteKey = key;
+      }
+    });
+
+    listenerMap.delete(deleteKey);
   }
 }
 

--- a/packages/api-electron/src/preload/message-service.js
+++ b/packages/api-electron/src/preload/message-service.js
@@ -1,5 +1,7 @@
 const ipc = require('electron').ipcRenderer;
 
+const listenerMap = new Map();
+
 class MessageService {
   static send(windowId, topic, message) {
     ipc.send('ssf-send-message', {
@@ -10,12 +12,36 @@ class MessageService {
   }
 
   static subscribe(windowId, topic, listener) {
-    ipc.on(`ssf-send-message-${topic}`, (message, sender) => {
+    const receiveMessage = (message, sender) => {
       // Check this was from the correct window
-      if (windowId === sender || windowId === '*') {
+      if (windowId === sender.toString() || windowId === '*') {
         listener(message, sender);
       }
+    };
+
+    ipc.on(`ssf-send-message-${topic}`, receiveMessage);
+
+    // Map the arguments to the actual listener that was added
+    listenerMap.set({
+      windowId,
+      topic,
+      listener
+    }, receiveMessage);
+  }
+
+  static unsubscribe(windowId, topic, listener) {
+    let deleteKey = null;
+
+    // We cant use listenerMap.has() here becuase reconsrtucting the key from the arguments is a different object
+    // i.e. {} !== {}
+    listenerMap.forEach((value, key) => {
+      if (key.windowId === windowId && key.topic === topic && key.listener === listener) {
+        ipc.removeListener(`ssf-send-message-${topic}`, value);
+        deleteKey = key;
+      }
     });
+
+    listenerMap.delete(deleteKey);
   }
 }
 

--- a/packages/api-electron/src/preload/message-service.js
+++ b/packages/api-electron/src/preload/message-service.js
@@ -32,7 +32,7 @@ class MessageService {
   static unsubscribe(windowId, topic, listener) {
     let deleteKey = null;
 
-    // We cant use listenerMap.has() here becuase reconsrtucting the key from the arguments is a different object
+    // We cant use listenerMap.has() here because reconstructing the key from the arguments is a different object
     // i.e. {} !== {}
     listenerMap.forEach((value, key) => {
       if (key.windowId === windowId && key.topic === topic && key.listener === listener) {

--- a/packages/api-openfin/src/message-service.js
+++ b/packages/api-openfin/src/message-service.js
@@ -19,6 +19,16 @@ class MessageService {
       fin.desktop.InterApplicationBus.subscribe(appId, topic, listener);
     }
   }
+
+  static unsubscribe(windowId, topic, listener) {
+    const [appId, windowName] = windowId.split(':');
+
+    if (appId && windowName) {
+      fin.desktop.InterApplicationBus.unsubscribe(appId, windowName, topic, listener);
+    } else if (appId) {
+      fin.desktop.InterApplicationBus.unsubscribe(appId, topic, listener);
+    }
+  }
 }
 
 export default MessageService;

--- a/packages/api-specification/src/messaging-api-demo.js
+++ b/packages/api-specification/src/messaging-api-demo.js
@@ -1,6 +1,8 @@
 const messageBox = document.getElementById('message-box');
 const sendButton = document.getElementById('send-message');
 const newWindowButton = document.getElementById('new-window');
+const subscribeButton = document.getElementById('subscribe-button');
+const unsubscribeButton = document.getElementById('unsubscribe-button');
 
 const appReady = ssf.app.ready();
 
@@ -16,15 +18,23 @@ appReady.then(() => {
 
     // eslint-disable-next-line no-new
     new ssf.Window(`http://localhost:${location.port}/messaging-api-test-window.html`, id, 'child=' + isChild);
-
-    ssf.MessageService.subscribe('*', 'test', (message, senderId) => {
-      messageBox.innerText = '\'' + message + '\' from ' + senderId;
-    });
   };
 
   sendButton.onclick = () => {
     const uuid = document.getElementById('uuid').value;
     const message = document.getElementById('message').value;
     ssf.MessageService.send(uuid, 'test', message);
+  };
+
+  const messageReceived = (message, senderId) => {
+    messageBox.innerText = '\'' + message + '\' from ' + senderId;
+  };
+
+  subscribeButton.onclick = () => {
+    ssf.MessageService.subscribe('*', 'test', messageReceived);
+  };
+
+  unsubscribeButton.onclick = () => {
+    ssf.MessageService.unsubscribe('*', 'test', messageReceived);
   };
 });

--- a/packages/api-specification/src/messaging-api.html
+++ b/packages/api-specification/src/messaging-api.html
@@ -54,6 +54,15 @@
 
   <hr/>
 
+  <h5>Subscribe and unsubscribe from the channel, default is unsubscribed</h5>
+
+  <form class="inline-form">
+    <button type="button" class="btn btn-default" id="subscribe-button">Subscribe</button>
+    <button type="button" class="btn btn-default" id="unsubscribe-button">Unsubscribe</button>
+  </form>
+
+  <hr/>
+
   <div class="panel panel-default">
     <div class="panel-heading">
       <h3 class="panel-title">Latest Message</h3>
@@ -109,7 +118,7 @@
       <p>Unsubscribes from messages from a particular window and topic that has already been subscribed to</p>
       <ul>
         <li><code>windowId</code> - id of the sending window.</li>
-        <li><code>topic</code> - the topic to listen for.</li>
+        <li><code>topic</code> - the topic that was subscribed to.</li>
         <li><code>listener</code> - the listener that was passed to subscribe.</li>
       </ul>
     </dd>

--- a/packages/api-specification/src/messaging-api.html
+++ b/packages/api-specification/src/messaging-api.html
@@ -101,6 +101,18 @@
         <li><code>listener</code> - callback that is invoked when a message is received with 2 paramaters: message and senderid.</li>
       </ul>
     </dd>
+    <dt>unsubscribe</dt>
+    <pre>
+      ssf.MessageService.unsubscribe(windowId, topic, listener);
+    </pre>
+    <dd>
+      <p>Unsubscribes from messages from a particular window and topic that has already been subscribed to</p>
+      <ul>
+        <li><code>windowId</code> - id of the sending window.</li>
+        <li><code>topic</code> - the topic to listen for.</li>
+        <li><code>listener</code> - the listener that was passed to subscribe.</li>
+      </ul>
+    </dd>
   </dl>
 </div>
 


### PR DESCRIPTION
Adds an unsubscribe method to the message service. Need to map the arguments to the modified listener in browser/Electron APIs, because we add extra checks before we call the listeners. This lets us unsubscribe later (using `ipc.removeListener` or `window.removeEventListener`). By making an object of all of the arguments as the key, it also lets us only remove listeners for that particular window/topic.