### PR TITLE
Window events

### DIFF
--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -19,6 +19,8 @@ class Window {
 
       addAccessibleWindow(name, this.innerWindow);
     }
+
+    this.eventListeners = new Map();
   }
 
   close() {
@@ -48,6 +50,40 @@ class Window {
     }
   }
 
+  addListener(event, listener) {
+    if (this.eventListeners.has(event)) {
+      const temp = this.eventListeners.get(event);
+      temp.push(listener);
+      this.eventListeners.set(event, temp);
+    } else {
+      this.eventListeners.set(event, [listener]);
+    }
+    this.innerWindow.addEventListener(eventMap[event], listener);
+  }
+
+  removeListener(event, listener) {
+    if (this.eventListeners.has(event)) {
+      let listeners = this.eventListeners.get(event);
+      let index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners = listeners.splice(index, 1);
+        this.eventListeners.set(listeners);
+      }
+    }
+
+    this.innerWindow.removeEventListener(eventMap[event], listener);
+  }
+
+  removeAllListeners() {
+    this.eventListeners.forEach((value, key) => {
+      value.forEach((listener) => {
+        this.innerWindow.removeEventListener(eventMap[key], listener);
+      });
+    });
+
+    this.eventListeners.clear();
+  }
+
   static getCurrentWindowId() {
     return window.name;
   };
@@ -75,6 +111,14 @@ const objectToFeaturesString = (features) => {
 
     return `${key}=${value}`;
   }).join(',');
+};
+
+const eventMap = {
+  'blur': 'blur',
+  'close': 'unload',
+  'focus': 'focus',
+  'hide': 'hidden',
+  'show': 'load'
 };
 
 export default Window;

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -17,6 +17,17 @@ class Window {
         features
       });
     }
+
+    ipc.send('ssf-window-subscribe-events', this.innerWindow.id);
+    this.listeners = new Map();
+
+    ipc.on('ssf-window-event', (windowId, e) => {
+      // Need to check if the event is for this window in case the
+      // current native window has subscribed to more than 1 window's events
+      if (windowId === this.innerWindow.id && this.listeners.has(e)) {
+        this.listeners.get(e).forEach((listener) => listener());
+      }
+    });
   }
 
   close() {
@@ -41,6 +52,24 @@ class Window {
 
   sendWindowAction(action) {
     ipc.send(action, this.innerWindow.id);
+  }
+
+  addListener(event, listener) {
+    if (this.listeners.has(event)) {
+      const listeners = this.listeners.get(event);
+      listeners.push(listener);
+      this.listeners.set(event, listeners);
+    } else {
+      this.listeners.set(event, [listener]);
+    }
+  }
+
+  removeListener(event, listener) {
+    if (this.listeners.has(event)) {
+      const listeners = this.listeners.get(event);
+      listeners.splice(listeners.indexOf(listener), 1);
+      this.listeners.set(event, listeners);
+    }
   }
 
   static getCurrentWindowId() {

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -66,8 +66,8 @@ class Window {
 
   removeListener(event, listener) {
     if (this.eventListeners.has(event)) {
-      const listeners = this.eventListeners.get(event);
-      listeners.splice(listeners.indexOf(listener), 1);
+      let listeners = this.eventListeners.get(event);
+      listeners = listeners.splice(listeners.indexOf(listener), 1);
       this.eventListeners.set(event, listeners);
     }
   }

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -19,13 +19,13 @@ class Window {
     }
 
     ipc.send('ssf-window-subscribe-events', this.innerWindow.id);
-    this.listeners = new Map();
+    this.eventListeners = new Map();
 
     ipc.on('ssf-window-event', (windowId, e) => {
       // Need to check if the event is for this window in case the
       // current native window has subscribed to more than 1 window's events
-      if (windowId === this.innerWindow.id && this.listeners.has(e)) {
-        this.listeners.get(e).forEach((listener) => listener());
+      if (windowId === this.innerWindow.id && this.eventListeners.has(e)) {
+        this.eventListeners.get(e).forEach((listener) => listener());
       }
     });
   }
@@ -55,21 +55,25 @@ class Window {
   }
 
   addListener(event, listener) {
-    if (this.listeners.has(event)) {
-      const listeners = this.listeners.get(event);
+    if (this.eventListeners.has(event)) {
+      const listeners = this.eventListeners.get(event);
       listeners.push(listener);
-      this.listeners.set(event, listeners);
+      this.eventListeners.set(event, listeners);
     } else {
-      this.listeners.set(event, [listener]);
+      this.eventListeners.set(event, [listener]);
     }
   }
 
   removeListener(event, listener) {
-    if (this.listeners.has(event)) {
-      const listeners = this.listeners.get(event);
+    if (this.eventListeners.has(event)) {
+      const listeners = this.eventListeners.get(event);
       listeners.splice(listeners.indexOf(listener), 1);
-      this.listeners.set(event, listeners);
+      this.eventListeners.set(event, listeners);
     }
+  }
+
+  removeAllListeners() {
+    this.eventListeners.clear();
   }
 
   static getCurrentWindowId() {

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -56,6 +56,14 @@ class Window {
     this.innerWindow.blur();
   }
 
+  addListener(event, listener) {
+    this.innerWindow.addEventListener(eventMap[event], listener);
+  }
+
+  removeListener(event, listener) {
+    this.innerWindow.removeEventListener(eventMap[event], listener);
+  }
+
   static getCurrentWindowId() {
     const currentWin = fin.desktop.Window.getCurrent();
     return `${currentWin.uuid}:${currentWin.name}`;
@@ -70,5 +78,32 @@ class Window {
     return currentWindow;
   }
 }
+
+const eventMap = {
+  'auth-requested': 'auth-requested',
+  'blur': 'blurred',
+  'move': 'bounds-changed',
+  'resize': 'bounds-changed',
+  'bounds-changing': 'bounds-changing',
+  'close-requested': 'close-requested',
+  'close': 'closed',
+  'disabled-frame-bounds-changed': 'disabled-frame-bounds-changed',
+  'disabled-frame-bounds-changing': 'disabled-frame-bounds-changing',
+  'embedded': 'embedded',
+  'external-process-exited': 'external-process-exited',
+  'external-process-started': 'external-process-started',
+  'focus': 'focused',
+  'frame-disabled': 'frame-disabled',
+  'frame-enabled': 'frame-enabled',
+  'group-changed': 'group-changed',
+  'hide': 'hidden',
+  'initialized': 'initialized',
+  'maximize': 'maximized',
+  'minimize': 'minimized',
+  'navigation-rejected': 'navigation-rejected',
+  'restore': 'restored',
+  'show-requested': 'show-requested',
+  'show': 'shown'
+};
 
 export default Window;

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -34,6 +34,8 @@ class Window {
       }
       this.innerWindow = newWindow;
     }
+
+    this.eventListeners = new Map();
   }
 
   close() {
@@ -57,11 +59,37 @@ class Window {
   }
 
   addListener(event, listener) {
+    if (this.eventListeners.has(event)) {
+      const temp = this.eventListeners.get(event);
+      temp.push(listener);
+      this.eventListeners.set(event, temp);
+    } else {
+      this.eventListeners.set(event, [listener]);
+    }
     this.innerWindow.addEventListener(eventMap[event], listener);
   }
 
   removeListener(event, listener) {
+    if (this.eventListeners.has(event)) {
+      let listeners = this.eventListeners.get(event);
+      let index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners = listeners.splice(index, 1);
+        this.eventListeners.set(listeners);
+      }
+    }
+
     this.innerWindow.removeEventListener(eventMap[event], listener);
+  }
+
+  removeAllListeners() {
+    this.eventListeners.forEach((value, key) => {
+      value.forEach((listener) => {
+        this.innerWindow.removeEventListener(eventMap[key], listener);
+      });
+    });
+
+    this.eventListeners.clear();
   }
 
   static getCurrentWindowId() {

--- a/packages/api-specification/src/style.css
+++ b/packages/api-specification/src/style.css
@@ -11,3 +11,8 @@ body {
 #screen-snippet-test-error {
   font-style: italic;
 }
+
+#event-log {
+  height: 300px;
+  overflow: auto;
+}

--- a/packages/api-specification/src/window-api-demo.js
+++ b/packages/api-specification/src/window-api-demo.js
@@ -1,4 +1,5 @@
 var newWindowButton = document.getElementById('new-window-test');
+var eventLogList = document.getElementById('event-log');
 
 const appReady = ssf.app.ready();
 
@@ -11,6 +12,46 @@ appReady.then(() => {
     var isChild = document.getElementById('child').checked;
     win = new ssf.Window(url, windowName, {
       child: isChild
+    });
+
+    win.addListener('hide', () => {
+      const newElem = document.createElement('li');
+      newElem.innerText = 'hide';
+      newElem.className = 'list-group-item';
+      eventLogList.appendChild(newElem);
+      eventLogList.scrollTop = eventLogList.scrollHeight;
+    });
+
+    win.addListener('show', () => {
+      const newElem = document.createElement('li');
+      newElem.innerText = 'show';
+      newElem.className = 'list-group-item';
+      eventLogList.appendChild(newElem);
+      eventLogList.scrollTop = eventLogList.scrollHeight;
+    });
+
+    win.addListener('blur', () => {
+      const newElem = document.createElement('li');
+      newElem.innerText = 'blur';
+      newElem.className = 'list-group-item';
+      eventLogList.appendChild(newElem);
+      eventLogList.scrollTop = eventLogList.scrollHeight;
+    });
+
+    win.addListener('focus', () => {
+      const newElem = document.createElement('li');
+      newElem.innerText = 'focus';
+      newElem.className = 'list-group-item';
+      eventLogList.appendChild(newElem);
+      eventLogList.scrollTop = eventLogList.scrollHeight;
+    });
+
+    win.addListener('close', () => {
+      const newElem = document.createElement('li');
+      newElem.innerText = 'close';
+      newElem.className = 'list-group-item';
+      eventLogList.appendChild(newElem);
+      eventLogList.scrollTop = eventLogList.scrollHeight;
     });
   };
 

--- a/packages/api-specification/src/window-api-demo.js
+++ b/packages/api-specification/src/window-api-demo.js
@@ -59,6 +59,8 @@ appReady.then(() => {
 
   closeWindow.onclick = () => {
     win.close();
+    win.removeAllListeners();
+    win = null;
   };
 
   var hideWindow = document.getElementById('hide-window');

--- a/packages/api-specification/src/window-api-demo.js
+++ b/packages/api-specification/src/window-api-demo.js
@@ -14,44 +14,32 @@ appReady.then(() => {
       child: isChild
     });
 
-    win.addListener('hide', () => {
+    const addListItem = (text) => {
       const newElem = document.createElement('li');
-      newElem.innerText = 'hide';
+      newElem.innerText = text;
       newElem.className = 'list-group-item';
       eventLogList.appendChild(newElem);
       eventLogList.scrollTop = eventLogList.scrollHeight;
+    };
+
+    win.addListener('hide', () => {
+      addListItem('hide');
     });
 
     win.addListener('show', () => {
-      const newElem = document.createElement('li');
-      newElem.innerText = 'show';
-      newElem.className = 'list-group-item';
-      eventLogList.appendChild(newElem);
-      eventLogList.scrollTop = eventLogList.scrollHeight;
+      addListItem('show');
     });
 
     win.addListener('blur', () => {
-      const newElem = document.createElement('li');
-      newElem.innerText = 'blur';
-      newElem.className = 'list-group-item';
-      eventLogList.appendChild(newElem);
-      eventLogList.scrollTop = eventLogList.scrollHeight;
+      addListItem('blur');
     });
 
     win.addListener('focus', () => {
-      const newElem = document.createElement('li');
-      newElem.innerText = 'focus';
-      newElem.className = 'list-group-item';
-      eventLogList.appendChild(newElem);
-      eventLogList.scrollTop = eventLogList.scrollHeight;
+      addListItem('focus');
     });
 
     win.addListener('close', () => {
-      const newElem = document.createElement('li');
-      newElem.innerText = 'close';
-      newElem.className = 'list-group-item';
-      eventLogList.appendChild(newElem);
-      eventLogList.scrollTop = eventLogList.scrollHeight;
+      addListItem('close');
     });
   };
 

--- a/packages/api-specification/src/window-api.html
+++ b/packages/api-specification/src/window-api.html
@@ -49,6 +49,14 @@
     <button id="blur-window" type="button" class="btn btn-default">Blur</button>
   </form>
 
+  <hr/>
+
+  <p>Event Log:</p>
+  <div class="well">
+    <ul id="event-log" class="list-group">
+    </ul>
+  </div>
+
   <h3>Overview</h3>
 
   <p>The Window API is used to create a new browser window.</p>

--- a/packages/api-specification/src/window-api.html
+++ b/packages/api-specification/src/window-api.html
@@ -111,11 +111,26 @@
   </ul>
   <h5>Class Methods</h5>
   <ul>
+    <li><code>addListener(event, callback)</code> - Add an event listener to execute a given callback</li>
     <li><code>blur()</code> - Remove focus from the window</li>
     <li><code>close()</code> - Close the window</li>
     <li><code>focus()</code> - Give the window focus</li>
     <li><code>hide()</code> - Hide a visible window (Non browser only)</li>
+    <li><code>removeListener(event, callback)</code> - Remove an event listener that was previously added</li>
+    <li><code>removeAllListeners()</code> - Remove all added listeners</li>
     <li><code>show()</code> - Show a hidden window (Non browser only)</li>
+  </ul>
+
+  <h5>Events</h5>
+  <ul>
+    <li><b>blur</b> - When the window has lost focus</li>
+    <li><b>close</b> - when the window has been closed</li>
+    <li><b>focus</b> - When the window has gained focus</li>
+    <li><b>hide</b> - When the window is hidden</li>
+    <li><b>maximize</b> - When the window is maximized (non browser)</li>
+    <li><b>minimize</b> - When the window is minimized (non browser)</li>
+    <li><b>restore</b> - When the window is restored from a minimized state (non browser)</li>
+    <li><b>show</b> - When the window is shown</li>
   </ul>
 </div>
 


### PR DESCRIPTION
Added window events, which can be subscribed to via `addListener(event, callback)` and removed using `removeListener(event, callback)`. The event strings that are used are the electron events (i.e. `blur`, `hide`, `show`) which get converted to the OpenFin/browser equivalent. Window events on the browser are limited.