### PR TITLE
Add postMessage to window API

### DIFF
--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -21,6 +21,7 @@ class Window {
     }
 
     this.eventListeners = new Map();
+    this.addListener('message', (event) => this.onMessage(event.data));
   }
 
   close() {
@@ -58,7 +59,7 @@ class Window {
     } else {
       this.eventListeners.set(event, [listener]);
     }
-    this.innerWindow.addEventListener(eventMap[event], listener);
+    this.innerWindow.addEventListener(eventMap[event] || event, listener);
   }
 
   removeListener(event, listener) {
@@ -71,18 +72,25 @@ class Window {
       }
     }
 
-    this.innerWindow.removeEventListener(eventMap[event], listener);
+    this.innerWindow.removeEventListener(eventMap[event] || event, listener);
   }
 
   removeAllListeners() {
     this.eventListeners.forEach((value, key) => {
       value.forEach((listener) => {
-        this.innerWindow.removeEventListener(eventMap[key], listener);
+        this.innerWindow.removeEventListener(eventMap[key] || key, listener);
       });
     });
 
     this.eventListeners.clear();
   }
+
+  postMessage(message) {
+    this.innerWindow.postMessage(message, '*');
+  }
+
+  // To be overridden by user
+  onMessage() {}
 
   static getCurrentWindowId() {
     return window.name;

--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -59,7 +59,7 @@ class Window {
     } else {
       this.eventListeners.set(event, [listener]);
     }
-    this.innerWindow.addEventListener(eventMap[event] || event, listener);
+    this.innerWindow.addEventListener(eventMap[event], listener);
   }
 
   removeListener(event, listener) {
@@ -72,13 +72,13 @@ class Window {
       }
     }
 
-    this.innerWindow.removeEventListener(eventMap[event] || event, listener);
+    this.innerWindow.removeEventListener(eventMap[event], listener);
   }
 
   removeAllListeners() {
     this.eventListeners.forEach((value, key) => {
       value.forEach((listener) => {
-        this.innerWindow.removeEventListener(eventMap[key] || key, listener);
+        this.innerWindow.removeEventListener(eventMap[key], listener);
       });
     });
 
@@ -126,6 +126,7 @@ const eventMap = {
   'close': 'unload',
   'focus': 'focus',
   'hide': 'hidden',
+  'message': 'message',
   'show': 'load'
 };
 

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -1,4 +1,5 @@
 const ipc = require('electron').ipcRenderer;
+import MessageService from './message-service';
 import constants from '../common/constants';
 
 let currentWindow = null;
@@ -29,6 +30,8 @@ class Window {
         this.eventListeners.get(e).forEach((listener) => listener());
       }
     });
+
+    MessageService.subscribe('*', 'ssf-window-message', (...args) => this.onMessage(...args));
   }
 
   close() {
@@ -76,6 +79,13 @@ class Window {
   removeAllListeners() {
     this.eventListeners.clear();
   }
+
+  postMessage(message) {
+    MessageService.send(this.innerWindow.id, 'ssf-window-message', message);
+  }
+
+  // To be overridden by user
+  onMessage() {}
 
   static getCurrentWindowId() {
     return ipc.sendSync(constants.ipc.SSF_GET_WINDOW_ID);

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -1,4 +1,5 @@
 let currentWindow = null;
+import MessageService from './message-service';
 
 class Window {
   constructor(...args) {
@@ -45,6 +46,7 @@ class Window {
       this.innerWindow = newWindow;
     }
 
+    MessageService.subscribe('*', 'ssf-window-message', (...args) => this.onMessage(...args));
     this.eventListeners = new Map();
   }
 
@@ -101,6 +103,13 @@ class Window {
 
     this.eventListeners.clear();
   }
+
+  postMessage(message) {
+    MessageService.send(`${this.innerWindow.uuid}:${this.innerWindow.name}`, 'ssf-window-message', message);
+  }
+
+  // To be overridden by user
+  onMessage() {}
 
   static getCurrentWindowId() {
     const currentWin = fin.desktop.Window.getCurrent();

--- a/packages/api-specification/src/messaging/messaging-api.md
+++ b/packages/api-specification/src/messaging/messaging-api.md
@@ -1,5 +1,5 @@
 ## Overview
-The Messaging API is used to communicate between windows
+The Messaging API is used to communicate between windows. Messages can also be send directly to a window using the window API.
 
 ### Methods
 The `MessageService` class exposes the following static methods:</p>

--- a/packages/api-specification/src/messaging/messaging-api.md
+++ b/packages/api-specification/src/messaging/messaging-api.md
@@ -1,5 +1,5 @@
 ## Overview
-The Messaging API is used to communicate between windows. Messages can also be send directly to a window using the window API.
+The Messaging API is used to communicate between windows. Messages can also be sent directly to a window using the window API.
 
 ### Methods
 The `MessageService` class exposes the following static methods:</p>

--- a/packages/api-specification/src/window/window-api.md
+++ b/packages/api-specification/src/window/window-api.md
@@ -41,6 +41,8 @@ A reference to the new window.
 * `close()` - Close the window
 * `focus()` - Give the window focus
 * `hide()` - Hide a visible window (Non browser only)
+* `onMessage` - Method that is called when the window receives a message from another window
+* `postMessage(message)` - Sends a message to the window, which can be received via the onMessage handler. `message` can be any serializable object
 * `removeListener(event, callback)` - Remove an event listener that was previously added
 * `removeAllListeners()` - Remove all added listeners
 * `show()` - Show a hidden window (Non browser only)


### PR DESCRIPTION
Adds `window.postMessage(message)` to the window API. In the browser, this uses `postMessage()`, whereas in OpenFin and Electron, it is just a wrapper around the `MessageService` call.