### PR TITLE
Change to onMessage listener

### DIFF
--- a/packages/api-browser/src/window.js
+++ b/packages/api-browser/src/window.js
@@ -34,7 +34,12 @@ class Window {
     }
 
     this.eventListeners = new Map();
-    this.addListener('message', (event) => this.onMessage(event.data));
+    this.addListener('message', (e) => {
+      const event = 'message';
+      if (this.eventListeners.has(event)) {
+        this.eventListeners.get(event).forEach(listener => listener(e.data));
+      }
+    });
   }
 
   close() {
@@ -74,7 +79,7 @@ class Window {
       let listeners = this.eventListeners.get(event);
       let index = listeners.indexOf(listener);
       if (index >= 0) {
-        listeners = listeners.splice(index, 1);
+        listeners.splice(index, 1);
         this.eventListeners.set(listeners);
       }
     }
@@ -95,9 +100,6 @@ class Window {
   postMessage(message) {
     this.innerWindow.postMessage(message, '*');
   }
-
-  // To be overridden by user
-  onMessage() {}
 
   static getCurrentWindowId() {
     return window.name;

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -46,7 +46,12 @@ class Window {
       }
     });
 
-    MessageService.subscribe('*', 'ssf-window-message', (...args) => this.onMessage(...args));
+    MessageService.subscribe('*', 'ssf-window-message', (...args) => {
+      const event = 'message';
+      if (this.eventListeners.has(event)) {
+        this.eventListeners.get(event).forEach(listener => listener(...args));
+      }
+    });
   }
 
   close() {
@@ -99,9 +104,12 @@ class Window {
 
   removeListener(event, listener) {
     if (this.eventListeners.has(event)) {
-      let listeners = this.eventListeners.get(event);
-      listeners = listeners.splice(listeners.indexOf(listener), 1);
-      this.eventListeners.set(event, listeners);
+      const listeners = this.eventListeners.get(event);
+      const index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+        this.eventListeners.set(event, listeners);
+      }
     }
   }
 
@@ -112,9 +120,6 @@ class Window {
   postMessage(message) {
     MessageService.send(this.innerWindow.id, 'ssf-window-message', message);
   }
-
-  // To be overridden by user
-  onMessage() {}
 
   static getCurrentWindowId() {
     return ipc.sendSync(IPC_SSF_GET_WINDOW_ID);

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -21,6 +21,7 @@ const eventMap = {
   'hide': 'hidden',
   'initialized': 'initialized',
   'maximize': 'maximized',
+  'message': 'message',
   'minimize': 'minimized',
   'navigation-rejected': 'navigation-rejected',
   'restore': 'restored',
@@ -118,8 +119,13 @@ class Window {
       this.innerWindow = newWindow;
     }
 
-    MessageService.subscribe('*', 'ssf-window-message', (...args) => this.onMessage(...args));
     this.eventListeners = new Map();
+    MessageService.subscribe('*', 'ssf-window-message', (...args) => {
+      const event = 'message';
+      if (this.eventListeners.has(event)) {
+        this.eventListeners.get(event).forEach(listener => listener(...args));
+      }
+    });
   }
 
   close() {
@@ -172,7 +178,7 @@ class Window {
   removeAllListeners() {
     this.eventListeners.forEach((value, key) => {
       value.forEach((listener) => {
-        this.innerWindow.removeEventListener(eventMap[key], listener);
+        this.innerWindow.removeEventListener(key, listener);
       });
     });
 
@@ -182,9 +188,6 @@ class Window {
   postMessage(message) {
     MessageService.send(`${this.innerWindow.uuid}:${this.innerWindow.name}`, 'ssf-window-message', message);
   }
-
-  // To be overridden by user
-  onMessage() {}
 
   static getCurrentWindowId() {
     const currentWin = fin.desktop.Window.getCurrent();

--- a/packages/api-specification/src/messaging/messaging-api-demo.js
+++ b/packages/api-specification/src/messaging/messaging-api-demo.js
@@ -17,7 +17,7 @@ appReady.then(() => {
     const isChild = document.getElementById('child').checked;
 
     // eslint-disable-next-line no-new
-    new ssf.Window(`http://localhost:${location.port}/messaging-api-test-window.html`, id, {child: isChild});
+    new ssf.Window(`http://localhost:${location.port}/messaging-api-test-window.html`, id, {child: isChild, show: true});
   };
 
   sendButton.onclick = () => {

--- a/packages/api-specification/src/window/window-api.md
+++ b/packages/api-specification/src/window/window-api.md
@@ -58,8 +58,7 @@ A reference to the new window.
 * `close()` - Close the window. Returns a promise that resolves to nothing
 * `focus()` - Give the window focus. Returns a promise that resolves to nothing
 * `hide()` - Hide a visible window (Non browser only). Returns a promise that resolves to nothing
-* `onMessage` - Method that is called when the window receives a message from another window
-* `postMessage(message)` - Sends a message to the window, which can be received via the onMessage handler. `message` can be any serializable object
+* `postMessage(message)` - Sends a message to the window. `message` can be any serializable object
 * `removeListener(event, callback)` - Remove an event listener that was previously added
 * `removeAllListeners()` - Remove all added listeners
 * `show()` - Show a hidden window (Non browser only). Returns a promise that resolves to nothing
@@ -70,6 +69,7 @@ A reference to the new window.
 * **focus** - When the window has gained focus
 * **hide** - When the window is hidden
 * **maximize** - When the window is maximized (non browser)
+* **message** - When the window receives a message from another window
 * **minimize** - When the window is minimized (non browser)
 * **restore** - When the window is restored from a minimized state (non browser)
 * **show** - When the window is shown


### PR DESCRIPTION
Changes the way we receive messages sent via `postMessage()`. We can now use `addListener('message', listener)` to listen for messages in the same way we can for other window messages.