### PR TITLE
Rename to containerjs

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-ssf-desktop-wrapper - Symphony Software Foundation
+ContainerJS - Symphony Software Foundation
 Copyright 2017 ScottLogic
 
 This product includes software developed at the Symphony Software Foundation (http://symphony.foundation).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ContainerJS
 
-This project contains the current work-in-progress Symphony Desktop Wrapper. The goal of this project is to provide a common API across multiple HTML5 containers. For more details, refer to the [confluence page](https://symphonyoss.atlassian.net/wiki/display/WGDWAPI/Working+Group+-+Desktop+Wrapper+API) for this working group.
+ContainerJS provides an abstraction layer over multiple HTML5 containers (OpenFin, Electron, Browser), that follows the Symphony Desktop APIs. For more details, refer to the [confluence page](https://symphonyoss.atlassian.net/wiki/display/WGDWAPI/Working+Group+-+Desktop+Wrapper+API) for this working group.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Symphony Desktop Wrapper
+# ContainerJS
 
 This project contains the current work-in-progress Symphony Desktop Wrapper. The goal of this project is to provide a common API across multiple HTML5 containers. For more details, refer to the [confluence page](https://symphonyoss.atlassian.net/wiki/display/WGDWAPI/Working+Group+-+Desktop+Wrapper+API) for this working group.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ssf-desktop-wrapper",
+  "name": "containerjs",
   "version": "0.0.0",
   "scripts": {
     "build": "lerna run build",

--- a/packages/api-browser-demo/README.md
+++ b/packages/api-browser-demo/README.md
@@ -1,6 +1,6 @@
-# Symphony API for Browsers Demo
+# ContainerJS API for Browsers Demo
 
-This project provides a demonstration of the Symphony Desktop Wrapper API for Browsers.
+This project provides a demonstration of ContainerJS which follows the Symphony Desktop Wrapper API for Browsers.
 
 ## Usage
 

--- a/packages/api-browser-demo/package.json
+++ b/packages/api-browser-demo/package.json
@@ -5,7 +5,7 @@
   "main": "",
   "scripts": {
     "start": "live-server --port=5002 src/",
-    "postinstall": "rimraf src && copyfiles -f 'node_modules/containerjs-api-specification/src/**' src && copyfiles -f 'node_modules/containerjs-api-browser/dist/**' src",
+    "postinstall": "rimraf src && copyfiles -f \"node_modules/containerjs-api-specification/src/**\" src && copyfiles -f \"node_modules/containerjs-api-browser/dist/**\" src",
     "test": "echo \"No test specified\" && exit 0"
   },
   "author": "",

--- a/packages/api-browser-demo/package.json
+++ b/packages/api-browser-demo/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "ssf-desktop-api-browser-demo",
+  "name": "containerjs-api-browser-demo",
   "version": "0.0.1",
   "description": "",
   "main": "",
   "scripts": {
     "start": "live-server --port=5002 src/",
-    "postinstall": "rimraf src && copyfiles -f 'node_modules/ssf-desktop-api-specification/src/**' src && copyfiles -f 'node_modules/ssf-desktop-api-browser/dist/**' src",
+    "postinstall": "rimraf src && copyfiles -f 'node_modules/containerjs-api-specification/src/**' src && copyfiles -f 'node_modules/containerjs-api-browser/dist/**' src",
     "test": "echo \"No test specified\" && exit 0"
   },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "ssf-desktop-api-specification": "0.0.1",
-    "ssf-desktop-api-browser": "0.0.1"
+    "containerjs-api-specification": "0.0.1",
+    "containerjs-api-browser": "0.0.1"
   },
   "devDependencies": {
     "copyfiles": "^1.2.0",

--- a/packages/api-browser/README.md
+++ b/packages/api-browser/README.md
@@ -1,6 +1,6 @@
-# Symphony API for Browsers
+# ContainerJS API for Browsers
 
-This project provides an implementation of the Symphony Desktop Wrapper API Specification for Browsers
+This project provides an implementation of ContainerJS which follows the Symphony Desktop Wrapper API Specification for Browsers
 
 ## Usage
 

--- a/packages/api-browser/package.json
+++ b/packages/api-browser/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ssf-desktop-api-browser",
+  "name": "containerjs-api-browser",
   "version": "0.0.1",
   "description": "",
   "main": "",

--- a/packages/api-electron-demo/README.md
+++ b/packages/api-electron-demo/README.md
@@ -1,6 +1,6 @@
-# Symphony API for Electron Demo
+# ContainerJS API for Electron Demo
 
-This project provides a demonstration of the Symphony Desktop Wrapper API within Electron.
+This project provides a demonstration of ContainerJS which follows the Symphony Desktop Wrapper API within Electron.
 
 ## Usage
 

--- a/packages/api-electron-demo/package.json
+++ b/packages/api-electron-demo/package.json
@@ -7,7 +7,7 @@
     "serve": "live-server --port=5000 --no-browser src/",
     "launch": "ssf-electron ./src/app.json",
     "start": "npm-run-all --parallel launch serve",
-    "postinstall": "rimraf src && copyfiles -f 'node_modules/containerjs-api-specification/src/**' src",
+    "postinstall": "rimraf src && copyfiles -f \"node_modules/containerjs-api-specification/src/**\" src",
     "test": "echo \"No test specified\" && exit 0"
   },
   "author": "",

--- a/packages/api-electron-demo/package.json
+++ b/packages/api-electron-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ssf-desktop-api-electron-demo",
+  "name": "containerjs-api-electron-demo",
   "version": "1.0.0",
   "description": "",
   "main": "main.js",
@@ -7,14 +7,14 @@
     "serve": "live-server --port=5000 --no-browser src/",
     "launch": "ssf-electron ./src/app.json",
     "start": "npm-run-all --parallel launch serve",
-    "postinstall": "rimraf src && copyfiles -f 'node_modules/ssf-desktop-api-specification/src/**' src",
+    "postinstall": "rimraf src && copyfiles -f 'node_modules/containerjs-api-specification/src/**' src",
     "test": "echo \"No test specified\" && exit 0"
   },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "ssf-desktop-api-specification": "0.0.1",
-    "ssf-desktop-api-electron": "0.0.1"
+    "containerjs-api-specification": "0.0.1",
+    "containerjs-api-electron": "0.0.1"
   },
   "devDependencies": {
     "copyfiles": "^1.2.0",

--- a/packages/api-electron/README.md
+++ b/packages/api-electron/README.md
@@ -1,6 +1,6 @@
-# Symphony API for Electron
+# ContainerJS API for Electron
 
-This project provides an implementation of the Symphony Desktop Wrapper API Specification for Electron
+This project provides an implementation of ContainerJS which follows the Symphony Desktop Wrapper API Specification for Electron
 
 ## Usage
 

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ssf-desktop-api-electron",
+  "name": "containerjs-api-electron",
   "version": "0.0.1",
   "description": "",
   "main": "index.js",

--- a/packages/api-openfin-demo/README.md
+++ b/packages/api-openfin-demo/README.md
@@ -1,6 +1,6 @@
-# Symphony API for OpenFin Demo
+# ContainerJS API for OpenFin Demo
 
-This project provides a demonstration of the Symphony Desktop Wrapper API within OpenFin.
+This project provides a demonstration of ContainerJS which follows the Symphony Desktop Wrapper API within OpenFin.
 
 ## Usage
 

--- a/packages/api-openfin-demo/package.json
+++ b/packages/api-openfin-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ssf-desktop-api-openfin-demo",
+  "name": "containerjs-desktop-api-openfin-demo",
   "version": "0.0.1",
   "description": "",
   "main": "",
@@ -7,15 +7,15 @@
     "serve": "live-server --port=5000 --no-browser src/",
     "launch": "openfin --launch --config ./src/app.json",
     "start": "npm-run-all --parallel serve launch",
-    "postinstall": "rimraf src && copyfiles -f 'node_modules/ssf-desktop-api-specification/src/**' src && copyfiles -f 'node_modules/ssf-desktop-api-openfin/dist/**' src",
+    "postinstall": "rimraf src && copyfiles -f 'node_modules/containerjs-api-specification/src/**' src && copyfiles -f 'node_modules/containerjs-api-openfin/dist/**' src",
     "test": "echo \"No test specified\" && exit 0"
   },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
     "openfin-cli": "^1.1.5",
-    "ssf-desktop-api-specification": "0.0.1",
-    "ssf-desktop-api-openfin": "0.0.1"
+    "containerjs-api-specification": "0.0.1",
+    "containerjs-api-openfin": "0.0.1"
   },
   "devDependencies": {
     "copyfiles": "^1.2.0",

--- a/packages/api-openfin-demo/package.json
+++ b/packages/api-openfin-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "containerjs-desktop-api-openfin-demo",
+  "name": "containerjs-api-openfin-demo",
   "version": "0.0.1",
   "description": "",
   "main": "",
@@ -7,7 +7,7 @@
     "serve": "live-server --port=5000 --no-browser src/",
     "launch": "openfin --launch --config ./src/app.json",
     "start": "npm-run-all --parallel serve launch",
-    "postinstall": "rimraf src && copyfiles -f 'node_modules/containerjs-api-specification/src/**' src && copyfiles -f 'node_modules/containerjs-api-openfin/dist/**' src",
+    "postinstall": "rimraf src && copyfiles -f \"node_modules/containerjs-api-specification/src/**\" src && copyfiles -f \"node_modules/containerjs-api-openfin/dist/**\" src",
     "test": "echo \"No test specified\" && exit 0"
   },
   "author": "",

--- a/packages/api-openfin/README.md
+++ b/packages/api-openfin/README.md
@@ -1,6 +1,6 @@
-# Symphony API for OpenFin
+# ContainerJS API for OpenFin
 
-This project provides an implementation of the Symphony Desktop Wrapper API Specification for OpenFin
+This project provides an implementation of ContainerJS which follows the Symphony Desktop Wrapper API Specification for OpenFin
 
 ## Usage
 

--- a/packages/api-openfin/package.json
+++ b/packages/api-openfin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ssf-desktop-api-openfin",
+  "name": "containerjs-api-openfin",
   "version": "0.0.1",
   "description": "",
   "main": "index.js",

--- a/packages/api-specification/README.md
+++ b/packages/api-specification/README.md
@@ -1,6 +1,6 @@
-# Symphony Desktop Wrapper API Specification
+# ContainerJS Desktop Wrapper API Specification
 
-This project both documents and demonstrates the Symphony Desktop Wrapper API specification.
+This project both documents and demonstrates ContainerJS which follows the Symphony Desktop Wrapper API specification.
 
 ## Getting started
 

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ssf-desktop-api-specification",
+  "name": "containerjs-api-specification",
   "version": "0.0.1",
   "description": "",
   "main": "index.js",

--- a/packages/api-specification/src/app/app-api.html
+++ b/packages/api-specification/src/app/app-api.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 
-<title>Symphony Desktop Wrapper API Specification</title>
+<title>ContainerJS</title>
 <link rel="stylesheet" type="text/css" href="bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="style.css"></link>
 
@@ -10,7 +10,7 @@
 <nav class="navbar navbar-inverse navbar-static-top">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="index.html">Symphony Desktop Wrapper API Demo</a>
+      <a class="navbar-brand" href="index.html">ContainerJS</a>
     </div>
   </div>
 </nav>

--- a/packages/api-specification/src/index.html
+++ b/packages/api-specification/src/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 
-<title>Symphony Desktop Wrapper API Specification</title>
+<title>ContainerJS</title>
 <link rel="stylesheet" type="text/css" href="bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="style.css"></link>
 
@@ -10,7 +10,7 @@
 <nav class="navbar navbar-inverse navbar-static-top">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="index.html">Symphony Desktop Wrapper API Demo</a>
+      <a class="navbar-brand" href="index.html">ContainerJS</a>
     </div>
   </div>
 </nav>

--- a/packages/api-specification/src/messaging/messaging-api-test-window.html
+++ b/packages/api-specification/src/messaging/messaging-api-test-window.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 
-<title>Symphony Desktop Wrapper API Specification</title>
+<title>ContainerJS</title>
 <link rel="stylesheet" type="text/css" href="bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="style.css"></link>
 
@@ -10,7 +10,7 @@
 <nav class="navbar navbar-inverse navbar-static-top">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="index.html">Symphony Desktop Wrapper API Demo</a>
+      <a class="navbar-brand" href="index.html">ContainerJS</a>
     </div>
   </div>
 </nav>

--- a/packages/api-specification/src/messaging/messaging-api.html
+++ b/packages/api-specification/src/messaging/messaging-api.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 
-<title>Symphony Desktop Wrapper API Specification</title>
+<title>ContainerJS</title>
 <link rel="stylesheet" type="text/css" href="bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="style.css"></link>
 
@@ -10,7 +10,7 @@
 <nav class="navbar navbar-inverse navbar-static-top">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="index.html">Symphony Desktop Wrapper API Demo</a>
+      <a class="navbar-brand" href="index.html">ContainerJS</a>
     </div>
   </div>
 </nav>

--- a/packages/api-specification/src/notifications/notification-api.html
+++ b/packages/api-specification/src/notifications/notification-api.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 
-<title>Symphony Desktop Wrapper API Specification</title>
+<title>ContainerJS</title>
 <link rel="stylesheet" type="text/css" href="bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="style.css"></link>
 
@@ -10,7 +10,7 @@
 <nav class="navbar navbar-inverse navbar-static-top">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="index.html">Symphony Desktop Wrapper API Demo</a>
+      <a class="navbar-brand" href="index.html">ContainerJS</a>
     </div>
   </div>
 </nav>

--- a/packages/api-specification/src/screen-snippet/screen-snippet-api.html
+++ b/packages/api-specification/src/screen-snippet/screen-snippet-api.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 
-<title>Symphony Desktop Wrapper API Specification</title>
+<title>ContainerJS</title>
 <link rel="stylesheet" type="text/css" href="bootstrap.min.css"></link>
 <link rel="stylesheet" type="text/css" href="style.css"></link>
 
@@ -10,7 +10,7 @@
 <nav class="navbar navbar-inverse navbar-static-top">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="index.html">Symphony Desktop Wrapper API Demo</a>
+      <a class="navbar-brand" href="index.html">ContainerJS</a>
     </div>
   </div>
 </nav>

--- a/packages/api-specification/src/window/window-api-compatability.md
+++ b/packages/api-specification/src/window/window-api-compatability.md
@@ -1,6 +1,6 @@
 ## Window Options Compatability Martix
 
-**Symphony**|**Electron**|**OpenFin**|**Browser**|**Notes**
+**ContainerJS**|**Electron**|**OpenFin**|**Browser**|**Notes**
 -----|-----|-----|-----|-----
 alwaysOnTop|alwaysOnTop|alwaysOnTop|</br>|
 backgroundColor|backgroundColor|backgroundColor|</br>|
@@ -28,7 +28,7 @@ y|y|defaultTop|</br>|
 
 ## Method Compatability Matrix
 
-**Symphony**|**Electron**|**OpenFin**|**Browser**|**Notes**
+**ContainerJS**|**Electron**|**OpenFin**|**Browser**|**Notes**
 -----|-----|-----|-----|-----
 blur|blur|blur|blur|
 close|close|close|close|
@@ -73,7 +73,7 @@ unmaximize|unmaximize|restore|</br>|
 
 ## Event Compatability Matrix
 
-**Symphony**|**Electron**|**OpenFin**|**Browser**
+**ContainerJS**|**Electron**|**OpenFin**|**Browser**
 -----|-----|-----|-----
 auth-requested|auth-requested|auth-requested|
 blur|blur|blurred|blur

--- a/packages/api-specification/src/window/window-api.html
+++ b/packages/api-specification/src/window/window-api.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 
-<title>Symphony Desktop Wrapper API Specification</title>
+<title>ContainerJS</title>
 <link rel="stylesheet" type="text/css" href="bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="style.css"></link>
 
@@ -10,7 +10,7 @@
 <nav class="navbar navbar-inverse navbar-static-top">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="index.html">Symphony Desktop Wrapper API Demo</a>
+      <a class="navbar-brand" href="index.html">ContainerJS</a>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
Replaces #65 (just one other place where the name needed changing, `NOTICE`)

Adding an additional fix relating to #64 