### PR TITLE
Some refactoring

### DIFF
--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -62,9 +62,9 @@ const convertOptions = (options) => {
   };
 
   Object.keys(optionsMap).forEach((optionKey) => {
-    const openfinOptionKey = optionsMap[optionKey];
+    const openFinOptionKey = optionsMap[optionKey];
     if (clonedOptions[optionKey]) {
-      clonedOptions[openfinOptionKey] = clonedOptions[optionKey];
+      clonedOptions[openFinOptionKey] = clonedOptions[optionKey];
       delete clonedOptions[optionKey];
     }
   });
@@ -164,7 +164,7 @@ class Window {
   }
 
   getBounds() {
-    return this.getBounds('focus')
+    return this.asPromise('getBounds')
       .then(bounds => ({
         x: bounds.left,
         y: bounds.top,

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -29,29 +29,6 @@ const eventMap = {
   'show': 'shown'
 };
 
-const optionsMap = {
-  'alwaysOnTop': 'alwaysOnTop',
-  'backgroundColor': 'backgroundColor',
-  'child': 'child',
-  'center': 'defaultCentered',
-  'frame': 'frame',
-  'hasShadow': 'shadow',
-  'height': 'defaultHeight',
-  'maxHeight': 'maxHeight',
-  'maximizable': 'maximizable',
-  'maxWidth': 'maxWidth',
-  'minHeight': 'minHeight',
-  'minimizable': 'minimizable',
-  'minWidth': 'minWidth',
-  'resizable': 'resizable',
-  'show': 'autoShow',
-  'skipTaskbar': 'showTaskbarIcon',
-  'transparent': 'opacity',
-  'width': 'defaultWidth',
-  'x': 'defaultLeft',
-  'y': 'defaultTop'
-};
-
 const windowStates = {
   MAXIMIZED: 'maximized',
   MINIMIZED: 'minimized',
@@ -59,21 +36,51 @@ const windowStates = {
 };
 
 const convertOptions = (options) => {
-  const convertedOptions = {};
+  let clonedOptions = Object.assign({}, options);
 
-  Object.keys(optionsMap).forEach((key) => {
-    const openfinOption = optionsMap[key];
-    convertedOptions[openfinOption] = options[key];
+  const optionsMap = {
+    'alwaysOnTop': 'alwaysOnTop',
+    'backgroundColor': 'backgroundColor',
+    'child': 'child',
+    'center': 'defaultCentered',
+    'frame': 'frame',
+    'hasShadow': 'shadow',
+    'height': 'defaultHeight',
+    'maxHeight': 'maxHeight',
+    'maximizable': 'maximizable',
+    'maxWidth': 'maxWidth',
+    'minHeight': 'minHeight',
+    'minimizable': 'minimizable',
+    'minWidth': 'minWidth',
+    'resizable': 'resizable',
+    'show': 'autoShow',
+    'skipTaskbar': 'showTaskbarIcon',
+    'transparent': 'opacity',
+    'width': 'defaultWidth',
+    'x': 'defaultLeft',
+    'y': 'defaultTop'
+  };
+
+  Object.keys(optionsMap).forEach((optionKey) => {
+    const openfinOptionKey = optionsMap[optionKey];
+    if (clonedOptions[optionKey]) {
+      clonedOptions[openfinOptionKey] = clonedOptions[optionKey];
+      delete clonedOptions[optionKey];
+    }
   });
 
-  if (options.transparent) {
+  if (clonedOptions.transparent) {
     // OpenFin needs opacity between 1 (not transparent) and 0 (fully transparent)
-    convertedOptions.opacity = options.transparent === true ? 0 : 1;
+    clonedOptions.opacity = clonedOptions.transparent === true ? 0 : 1;
+    delete clonedOptions.transparent;
   }
 
-  convertedOptions.showTaskbarIcon = !options.skipTaskbar;
+  if (clonedOptions.skipTaskbar) {
+    convertedOptions.showTaskbarIcon = !clonedOptions.skipTaskbar;
+    delete clonedOptions.skipTaskbar;
+  }
 
-  return convertedOptions;
+  return clonedOptions;
 };
 
 class Window {
@@ -98,23 +105,18 @@ class Window {
 
     MessageService.subscribe('*', 'test2', (message) => console.log(message));
 
-    const convertedOptions = convertOptions(options);
-    const mergedOptions = Object.assign(
-      {},
-      convertedOptions,
-      options
-    );
+    const openFinOptions = convertOptions(options);
 
-    if (mergedOptions.child) {
+    if (openFinOptions.child) {
       const currentWindow = Window.getCurrentWindow();
       currentWindow.children.push(this);
-      this.innerWindow = new fin.desktop.Window(mergedOptions, callback, errorCallback);
+      this.innerWindow = new fin.desktop.Window(openFinOptions, callback, errorCallback);
     } else {
       const appOptions = {
-        name: mergedOptions.name,
-        url: mergedOptions.url,
-        uuid: mergedOptions.name, // UUID must be the same as name
-        mainWindowOptions: mergedOptions
+        name: openFinOptions.name,
+        url: openFinOptions.url,
+        uuid: openFinOptions.name, // UUID must be the same as name
+        mainWindowOptions: openFinOptions
       };
 
       const app = new fin.desktop.Application(appOptions, (successObject) => {

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -76,7 +76,7 @@ const convertOptions = (options) => {
   }
 
   if (clonedOptions.skipTaskbar) {
-    convertedOptions.showTaskbarIcon = !clonedOptions.skipTaskbar;
+    clonedOptions.showTaskbarIcon = !clonedOptions.skipTaskbar;
     delete clonedOptions.skipTaskbar;
   }
 
@@ -133,7 +133,7 @@ class Window {
     return new Promise((resolve, reject) => {
       if (this.innerWindow) {
         const openFinFunction = this.innerWindow[fn];
-        openFinFunction.call(this.innerWindow, ...args, resolve, reject)
+        openFinFunction.call(this.innerWindow, ...args, resolve, reject);
       } else {
         reject(new Error('The window does not exist or the window has been closed'));
       }
@@ -324,7 +324,7 @@ class Window {
   }
 
   maximize() {
-    return this.asPromise('maximize', width, height);
+    return this.asPromise('maximize');
   }
 
   minimize() {


### PR DESCRIPTION
There was quite a bit of boiler-plate within the OpenFin window implementation in order to adapt the API to Promise-based. Within https://github.com/ColinEberhardt/ssf-desktop-wrapper/commit/01c50fb8b2cd8db9ede941d51f957592bcd5f7dd I've created a generic `asPromise` function that adapts the OpenFin API methods.

Other very minor things, make use of implicit returns with arrow functions, e.g. `f => { return 'bar' }` can be replaced with `f => 'bar'`.

I've also changed the way options are mapped so that un-used options are not passed through to OpenFin. Another minor tweak, I've moved the constant that defines the mappings into the function that uses it (I prefer to restrict the scope of constants / variables as much as possible - I'll let the JIT compiler worry about optimising this!)