### PR TITLE
Bugfixes for ipc calls and OpenFin window API

### DIFF
--- a/packages/api-electron/src/preload/message-service.js
+++ b/packages/api-electron/src/preload/message-service.js
@@ -13,7 +13,7 @@ class MessageService {
   }
 
   static subscribe(windowId, topic, listener) {
-    const receiveMessage = (message, sender) => {
+    const receiveMessage = (event, message, sender) => {
       // Check this was from the correct window
       if (windowId === sender.toString() || windowId === '*') {
         listener(message, sender);

--- a/packages/api-electron/src/preload/screen-snippet.js
+++ b/packages/api-electron/src/preload/screen-snippet.js
@@ -4,7 +4,7 @@ import { IpcMessages } from '../common/constants';
 class ScreenSnippet {
   capture() {
     return new Promise((resolve) => {
-      ipc.once(IpcMessages.IPC_SSF_SCREEN_SNIPPET_CAPTURED, (imageDataUri) => {
+      ipc.once(IpcMessages.IPC_SSF_SCREEN_SNIPPET_CAPTURED, (event, imageDataUri) => {
         resolve(imageDataUri);
       });
       ipc.send(IpcMessages.IPC_SSF_CAPTURE_SCREEN_SNIPPET);

--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -44,7 +44,7 @@ class Window {
     currentWin.children.push(this);
 
     ipc.send(IpcMessages.IPC_SSF_WINDOW_SUBSCRIBE_EVENTS, this.innerWindow.id);
-    ipc.on(IpcMessages.IPC_SSF_WINDOW_EVENT, (windowId, e) => {
+    ipc.on(IpcMessages.IPC_SSF_WINDOW_EVENT, (event, windowId, e) => {
       // Need to check if the event is for this window in case the
       // current native window has subscribed to more than 1 window's events
       if (windowId === this.innerWindow.id && this.eventListeners.has(e)) {
@@ -212,11 +212,11 @@ class Window {
       const errorEvent = `${action}${IpcModifiers.ERROR}-${nonce}`;
 
       ipc.send(action, this.innerWindow.id, nonce, args);
-      ipc.once(successEvent, (response) => {
+      ipc.once(successEvent, (event, response) => {
         ipc.removeListener(errorEvent, reject);
         resolve(response);
       });
-      ipc.once(errorEvent, (error) => {
+      ipc.once(errorEvent, (event, error) => {
         ipc.removeListener(successEvent, resolve);
         reject(new Error(error));
       });

--- a/packages/api-openfin/src/message-service.js
+++ b/packages/api-openfin/src/message-service.js
@@ -13,8 +13,6 @@ class MessageService {
   static subscribe(windowId, topic, listener) {
     const [appId, windowName] = windowId.split(':');
 
-    console.log(windowId, topic);
-
     if (appId && windowName) {
       fin.desktop.InterApplicationBus.subscribe(appId, windowName, topic, listener);
     } else if (appId) {

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -65,7 +65,9 @@ const convertOptions = (options) => {
     const openFinOptionKey = optionsMap[optionKey];
     if (clonedOptions[optionKey]) {
       clonedOptions[openFinOptionKey] = clonedOptions[optionKey];
-      delete clonedOptions[optionKey];
+      if (openFinOptionKey !== optionKey) {
+        delete clonedOptions[optionKey];
+      }
     }
   });
 
@@ -102,8 +104,6 @@ class Window {
       }
       return this;
     }
-
-    MessageService.subscribe('*', 'test2', (message) => console.log(message));
 
     const openFinOptions = convertOptions(options);
 


### PR DESCRIPTION
* A bug was found in the OpenFin API where it was deleting any options that were the same in the map (e.g. child) which was causing the tests to fail. This has been fixed.
* Fixed ipc.once listeners taking 1 parameter, not 2