### PR TITLE
Fix chain promise method

### DIFF
--- a/packages/api-tests/test/test-helpers.js
+++ b/packages/api-tests/test/test-helpers.js
@@ -21,7 +21,7 @@ const openNewWindow = (client, options) => {
 };
 /* eslint-enable no-undef, no-new */
 
-const chainPromises = (promises) => promises.reduce((acc, cur) => acc.then(cur), promises[0]());
+const chainPromises = (promises) => promises.reduce((acc, cur) => acc.then(cur), Promise.resolve());
 
 module.exports = {
   executeAsyncJavascript,


### PR DESCRIPTION
`chainPromises` was wrong for 2 reasons:
- It assumed the first method was returning a promise, which may not be the case (although most likely it would be)
- It was calling the first function twice, once when the method was first run and once when the reduce started

This fixes both those problems