### PR TITLE
Fix for OpenFin displaying undefined as string

### DIFF
--- a/packages/api-openfin/src/notification.html
+++ b/packages/api-openfin/src/notification.html
@@ -24,8 +24,8 @@
   <p id="body"></p>
   <script>
     function onNotificationMessage(message) {
-      document.getElementById('message').innerText = message.title;
-      document.getElementById('body').innerText = message.text;
+      document.getElementById('message').textContent = message.title;
+      document.getElementById('body').textContent = message.text;
     }
   </script>
 </body>


### PR DESCRIPTION
`document.getElementById('message').innerText = undefined` displays the string undefined, not an empty string.