### PR TITLE
Fix failing spectron tests

### DIFF
--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -57,9 +57,7 @@ module.exports = (appJson) => {
 
     const senderId = e.sender.id;
 
-    // Need to send to topic and * in case the user has subscribed to the wildcard
     destinationWindow.webContents.send(`${IpcMessages.IPC_SSF_SEND_MESSAGE}-${msg.topic}`, msg.message, senderId);
-    destinationWindow.webContents.send(`${IpcMessages.IPC_SSF_SEND_MESSAGE}-*`, msg.message, senderId);
   });
 
   createInitialHiddenWindow(appJson);

--- a/packages/api-specification/src/window/window-api-demo.js
+++ b/packages/api-specification/src/window/window-api-demo.js
@@ -35,34 +35,34 @@ appReady.then(() => {
       width,
       shadow: true,
       url
-    });
+    }, () => {
+      const addListItem = (text) => {
+        const newElem = document.createElement('li');
+        newElem.innerText = text;
+        newElem.className = 'list-group-item';
+        eventLogList.appendChild(newElem);
+        eventLogList.scrollTop = eventLogList.scrollHeight;
+      };
 
-    const addListItem = (text) => {
-      const newElem = document.createElement('li');
-      newElem.innerText = text;
-      newElem.className = 'list-group-item';
-      eventLogList.appendChild(newElem);
-      eventLogList.scrollTop = eventLogList.scrollHeight;
-    };
+      win.addListener('hide', () => {
+        addListItem('hide');
+      });
 
-    win.addListener('hide', () => {
-      addListItem('hide');
-    });
+      win.addListener('show', () => {
+        addListItem('show');
+      });
 
-    win.addListener('show', () => {
-      addListItem('show');
-    });
+      win.addListener('blur', () => {
+        addListItem('blur');
+      });
 
-    win.addListener('blur', () => {
-      addListItem('blur');
-    });
+      win.addListener('focus', () => {
+        addListItem('focus');
+      });
 
-    win.addListener('focus', () => {
-      addListItem('focus');
-    });
-
-    win.addListener('close', () => {
-      addListItem('close');
+      win.addListener('close', () => {
+        addListItem('close');
+      });
     });
   };
 

--- a/packages/api-tests/test/messaging.spec.js
+++ b/packages/api-tests/test/messaging.spec.js
@@ -63,7 +63,7 @@ describe('Messaging API', function(done) {
   });
 
   describe('Send message', () => {
-    it('Should send message string correctly', function() {
+    it('Should send string correctly', function() {
       const message = 'message';
 
       const steps = [
@@ -81,7 +81,7 @@ describe('Messaging API', function(done) {
       return chainPromises(steps);
     });
 
-    it('Should send javascript object message correctly', function() {
+    it('Should send javascript object correctly', function() {
       const message = {
         a: 1,
         b: '20'
@@ -135,7 +135,7 @@ describe('Messaging API', function(done) {
   });
 
   describe('Receive message', () => {
-    it('Should subscribe to the correct topic calls listener', function() {
+    it('Should call listener when subscribed to correct topic', function() {
       const message = 'message';
 
       const steps = [
@@ -153,7 +153,7 @@ describe('Messaging API', function(done) {
       return chainPromises(steps);
     });
 
-    it('Should subscribe to the wildcard topic calls listener', function() {
+    it('Should not call listener when subscribed to wildcard topic', function() {
       const message = 'message';
 
       const steps = [
@@ -165,7 +165,7 @@ describe('Messaging API', function(done) {
         () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
         () => selectWindow(app.client, 1),
         () => executeAsyncJavascript(app.client, getMessageScript),
-        (result) => assert.equal(result.value, message)
+        (result) => assert.equal(result.value, undefined)
       ];
 
       return chainPromises(steps);

--- a/packages/api-tests/test/window.spec.js
+++ b/packages/api-tests/test/window.spec.js
@@ -296,7 +296,8 @@ describe('Window API', function(done) {
       const xValue = 100;
       const windowOptions = getWindowOptions({
         name: windowTitle,
-        x: xValue
+        x: xValue,
+        y: 0
       });
 
       const steps = [
@@ -313,6 +314,7 @@ describe('Window API', function(done) {
       const yValue = 100;
       const windowOptions = getWindowOptions({
         name: windowTitle,
+        x: 0,
         y: yValue
       });
 


### PR DESCRIPTION
Fixes 3 tests cases:
- Message Service subscribing to wildcard topic (this isn't possible in OpenFin, so changed the test to 'should not call listener when subscribed to wildcard topic' and changed the Electron API to match)
- Window x and y options were failing, because in Electron the window needs both x and y value to set the window position.

Closes #96 