### PR TITLE
Fix for window being undefined in demo

### DIFF
--- a/packages/api-electron/src/preload/window.js
+++ b/packages/api-electron/src/preload/window.js
@@ -18,7 +18,7 @@ class Window {
     if (!options) {
       this.innerWindow = remote.getCurrentWindow();
       if (callback) {
-        callback();
+        callback(this);
       }
       return this;
     }
@@ -31,7 +31,7 @@ class Window {
     this.innerWindow = BrowserWindow.fromId(this.id);
 
     if (callback) {
-      callback();
+      callback(this);
     }
   }
 

--- a/packages/api-openfin/src/window.js
+++ b/packages/api-openfin/src/window.js
@@ -100,7 +100,7 @@ class Window {
     if (!options) {
       this.innerWindow = fin.desktop.Window.getCurrent();
       if (callback) {
-        callback();
+        callback(this);
       }
       return this;
     }
@@ -110,7 +110,12 @@ class Window {
     if (openFinOptions.child) {
       const currentWindow = Window.getCurrentWindow();
       currentWindow.children.push(this);
-      this.innerWindow = new fin.desktop.Window(openFinOptions, callback, errorCallback);
+      this.innerWindow = new fin.desktop.Window(openFinOptions, () => {
+        // We want to return our window, not the OpenFin window
+        if (callback) {
+          callback(this);
+        }
+      }, errorCallback);
     } else {
       const appOptions = {
         name: openFinOptions.name,
@@ -123,7 +128,7 @@ class Window {
         app.run();
         this.innerWindow = app.getWindow();
         if (callback) {
-          callback(successObject);
+          callback(this);
         }
       }, errorCallback);
     }

--- a/packages/api-specification/src/window/window-api-demo.js
+++ b/packages/api-specification/src/window/window-api-demo.js
@@ -35,7 +35,7 @@ appReady.then(() => {
       width,
       shadow: true,
       url
-    }, () => {
+    }, (win) => {
       const addListItem = (text) => {
         const newElem = document.createElement('li');
         newElem.innerText = text;


### PR DESCRIPTION
The success callback is called before the window constructor returns, meaning win was undefined in the demo. Passing the window object into the callback gives access to the window object in that callback