### PR TITLE
Added encrypted token to clabot configuration

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -6,5 +6,6 @@
     "JohnEz"
   ],
   "label": "cla-signed",
-  "message": "Thank you for your pull request and welcome to our community. We require contributors to sign our Contributor License Agreement, and we don't seem to have you on file. In order for us to review and merge your code, please contact @ColinEberhardt to find out how to get yourself added."
+  "message": "Thank you for your pull request and welcome to our community. We require contributors to sign our Contributor License Agreement, and we don't seem to have you on file. In order for us to review and merge your code, please contact @ColinEberhardt to find out how to get yourself added.",
+  "token": "HH6ZdxD9Myb+tr3OblmhhwJh/LFkhB7Y2xYli7pY2o5K4jiEdN9fKHutbtAiDNogg6ACjjAjcDXtrabFc7J+6EjOMoZA1XIiF+NE1g9Hf0JJ68VGwLQVTvziFTVOb5+shc1oRgHDfNjNjkPXlxDZSxT089vdkog8NaClJ/Ufs3U="
 }


### PR DESCRIPTION
Previously the bot has to be added as a collaborator with write access to the repo, which is a bit nasty. Now the bot performs write operations via an access token which grants selective privileges on the repo. This token is encrypted and added to the config file.

This update also allows the bot to add status checks to pull requests.