### PR TITLE
Fix test matrix styling

### DIFF
--- a/docs/docs/test-matrix.md
+++ b/docs/docs/test-matrix.md
@@ -34,7 +34,7 @@ sectionid: docs
 |ssf.Window.isMinimizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.isMinimized|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.isResizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
-|ssf.Window.loadURL|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.loadURL|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.maximize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.maximized|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.minimize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
@@ -42,7 +42,7 @@ sectionid: docs
 |ssf.Window.restore|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.setAlwaysOnTop|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.setBounds|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
-|ssf.Window.setIcon|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setIcon|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
 |ssf.Window.setMaximizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.setMaximumSize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.setMinimizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|

--- a/docs/docs/test-matrix.md
+++ b/docs/docs/test-matrix.md
@@ -6,49 +6,50 @@ layout: docs
 sectionid: docs
 ---
 
+{: width="100%"}
 | Method | Electron | OpenFin |
 |:---|:---:|:---:|
-|ssf.MessageService.receive|<div style="background-color:#50ce5b">4/4</div>|<div style="background-color:#50ce5b">4/4</div>|
-|ssf.MessageService.send|<div style="background-color:#50ce5b">3/3</div>|<div style="background-color:#50ce5b">3/3</div>|
-|ssf.Window()|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window(x)|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window(y)|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.alwaysOnTop|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.blur|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.close|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.flashFrame|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.focus|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.getBounds|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.getChildWindows|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.getMaximumSize|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.getMinimumSize|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.getParentWindow|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.getPosition|<div style="background-color:#50ce5b">2/2</div>|<div style="background-color:#50ce5b">2/2</div>|
-|ssf.Window.getSize|<div style="background-color:#50ce5b">2/2</div>|<div style="background-color:#50ce5b">2/2</div>|
-|ssf.Window.getTitle|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.hasShadow|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.hide|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.isMaximizable|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.isMaximized|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.isMinimizable|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.isMinimized|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.isResizable|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.loadURL|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.maximize|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.maximized|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.minimize|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.reload|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.restore|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setAlwaysOnTop|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setBounds|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setIcon|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.setMaximizable|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setMaximumSize|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setMinimizable|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setMinimumSize|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setPosition|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setResizable|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setSize|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
-|ssf.Window.setSkipTaskbar|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.show|<div style="background-color:">0/0</div>|<div style="background-color:">0/0</div>|
-|ssf.Window.unmaximize|<div style="background-color:#50ce5b">1/1</div>|<div style="background-color:#50ce5b">1/1</div>|
+|ssf.MessageService.receive|<span style="background-color:#50ce5b; display: block;">4/4</span>|<span style="background-color:#50ce5b; display: block;">4/4</span>|
+|ssf.MessageService.send|<span style="background-color:#50ce5b; display: block;">3/3</span>|<span style="background-color:#50ce5b; display: block;">3/3</span>|
+|ssf.Window()|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window(x)|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window(y)|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.alwaysOnTop|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.blur|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.close|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.flashFrame|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.focus|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.getBounds|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.getChildWindows|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.getMaximumSize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.getMinimumSize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.getParentWindow|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.getPosition|<span style="background-color:#50ce5b; display: block;">2/2</span>|<span style="background-color:#50ce5b; display: block;">2/2</span>|
+|ssf.Window.getSize|<span style="background-color:#50ce5b; display: block;">2/2</span>|<span style="background-color:#50ce5b; display: block;">2/2</span>|
+|ssf.Window.getTitle|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.hasShadow|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.hide|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.isMaximizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.isMaximized|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.isMinimizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.isMinimized|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.isResizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.loadURL|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.maximize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.maximized|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.minimize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.reload|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.restore|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setAlwaysOnTop|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setBounds|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setIcon|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setMaximizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setMaximumSize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setMinimizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setMinimumSize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setPosition|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setResizable|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setSize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
+|ssf.Window.setSkipTaskbar|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.show|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.unmaximize|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|

--- a/packages/api-tests/generate-test-matrix.js
+++ b/packages/api-tests/generate-test-matrix.js
@@ -89,7 +89,7 @@ sortedTags.forEach((tag) => {
   const electronColor = total > 0 ? getColorCode((electronPassed / total) * 100) : '';
   const openfinColor = total > 0 ? getColorCode((openfinPassed / total) * 100) : '';
   const label = tag.substring(1); // Removes the # from the front of the tag
-  markdownString += `|${label}|<div style="background-color:${electronColor}">${electronPassed}/${total}</div>|<div style="background-color:${openfinColor}">${openfinPassed}/${total}</div>|\n`;
+  markdownString += `|${label}|<span style="background-color:${electronColor}; display: block;">${electronPassed}/${total}</span>|<span style="background-color:${openfinColor}; display: block;">${openfinPassed}/${total}</span>|\n`;
 });
 
 const ghPagesMarkdown =
@@ -100,6 +100,7 @@ permalink: docs/test-matrix.html
 layout: docs
 sectionid: docs
 ---\n
+{: width="100%"}
 `;
 
 fs.writeFileSync(path.join(__dirname, '..', '..', 'docs', 'docs', 'test-matrix.md'), ghPagesMarkdown + markdownString);


### PR DESCRIPTION
The test matrix was being styled incorrectly on GitHub pages (the `div` tags were being rendered as text and not colored). Changing to span tags fixes the issue.