### PR TITLE
Fix loadURL test

### DIFF
--- a/packages/api-tests/demo/load-url-test.html
+++ b/packages/api-tests/demo/load-url-test.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <div>LOADED</div>
+    <script src="containerjs-api.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
The `loadURL` window test was broken because the callback wasn't being run once the method had been called, resulting in a timeout. This change runs the method inside a `setTimeout` so we can run the callback, and then execute `window.location.href` on the window once the page has loaded.

Closes #108 