### PR TITLE
Limit Lerna bootstrap concurrency on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 
 install:
   - ps: Install-Product node
+  - set CI=true
   - appveyor-retry npm install
 
 test_script:


### PR DESCRIPTION
Lerna bootstrap has been running concurrently on AppVeyor - I expect this has been the cause of the occasional failures during npm install/postinstall. This change sets the `CI` environment variable to `true` to ensure the bootstrap process isn't run concurrently.