### PR TITLE
Added specific OpenFin and Electron tests

### DIFF
--- a/docs/docs/test-matrix.md
+++ b/docs/docs/test-matrix.md
@@ -24,7 +24,7 @@ sectionid: docs
 |ssf.Window.focus|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
 |ssf.Window.getBounds|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.getChildWindows|<span style="background-color:#50ce5b; display: block;">2/2</span>|<span style="background-color:#50ce5b; display: block;">2/2</span>|
-|ssf.Window.getId|<span style="background-color:; display: block;">0/0</span>|<span style="background-color:; display: block;">0/0</span>|
+|ssf.Window.getId|<span style="background-color:#50ce5b; display: block;">1/1</span>|<span style="background-color:#50ce5b; display: block;">1/1</span>|
 |ssf.Window.getMaximumSize|<span style="background-color:#50ce5b; display: block;">2/2</span>|<span style="background-color:#50ce5b; display: block;">2/2</span>|
 |ssf.Window.getMinimumSize|<span style="background-color:#50ce5b; display: block;">2/2</span>|<span style="background-color:#50ce5b; display: block;">2/2</span>|
 |ssf.Window.getParentWindow|<span style="background-color:#50ce5b; display: block;">2/2</span>|<span style="background-color:#50ce5b; display: block;">2/2</span>|

--- a/packages/api-tests/test/window.spec.js
+++ b/packages/api-tests/test/window.spec.js
@@ -179,22 +179,6 @@ describe('Window API', function(done) {
       return chainPromises(steps);
     });
 
-    it.skip('Should return the id of the window #ssf.Window.getId', function() {
-      const windowTitle = 'windownameclose';
-      const windowOptions = getWindowOptions({
-        name: windowTitle
-      });
-
-      const steps = [
-        ...setupWindowSteps(windowOptions),
-        () => selectWindow(app.client, 1),
-        () => callWindowMethod('getId'),
-        (result) => assert.equal(result.value, null)
-      ];
-
-      return chainPromises(steps);
-    });
-
     it('Should return the maximum width #ssf.Window.getMaximumSize', function() {
       const windowTitle = 'windownamemaxwidth';
       const maxWidth = 500;
@@ -887,6 +871,42 @@ describe('Window API', function(done) {
 
       return chainPromises(steps);
     });
+
+    if (process.env.MOCHA_CONTAINER === 'electron') {
+      it('Should return the id of the window #ssf.Window.getId', function() {
+        const windowTitle = 'windownameid';
+        const windowOptions = getWindowOptions({
+          name: windowTitle
+        });
+
+        const steps = [
+          ...setupWindowSteps(windowOptions),
+          () => selectWindow(app.client, 1),
+          () => callWindowMethod('getId'),
+          (result) => assert.equal(result.value, 2)
+        ];
+
+        return chainPromises(steps);
+      });
+    }
+
+    if (process.env.MOCHA_CONTAINER === 'openfin') {
+      it('Should return the id of the window #ssf.Window.getId', function() {
+        const windowTitle = 'windownameid';
+        const windowOptions = getWindowOptions({
+          name: windowTitle
+        });
+
+        const steps = [
+          ...setupWindowSteps(windowOptions),
+          () => selectWindow(app.client, 1),
+          () => callWindowMethod('getId'),
+          (result) => assert.equal(result.value, `ssf-desktop-api-openfin-demo:${windowTitle}`)
+        ];
+
+        return chainPromises(steps);
+      });
+    }
   });
 
   describe('New Window', function() {


### PR DESCRIPTION
These tests could be done as a single one with just the expected answer changed, however i thought it would be a good idea to put in an example of how to add specific tests for each container but also show that the test matrix still works with unit tests like these.

This way of writing specific tests instead of using tags means that its simpler to run tests overall however each describe that needs to do this will need to have an if statement in it.