### PR TITLE
remove the interface copy step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,11 +71,6 @@ transpiled/
 # Test output
 /packages/api-tests/coverage/
 
-# Interfaces
-/packages/api-browser/src/interface.ts
-/packages/api-electron/src/interface.ts
-/packages/api-openfin/src/interface.ts
-
 # Docs output
 /packages/api-specification/test-report.json
 /packages/api-specification/type-info.json

--- a/packages/api-browser/package.json
+++ b/packages/api-browser/package.json
@@ -5,8 +5,7 @@
   "main": "",
   "scripts": {
     "build": "rimraf dist transpiled && tsc && rollup -c && rimraf transpiled",
-    "test": "npm run build",
-    "postinstall": "copyfiles -f \"node_modules/containerjs-api-specification/interface.ts\" src/ && npm run build"
+    "test": "npm run build"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/api-browser/preload.ts
+++ b/packages/api-browser/preload.ts
@@ -2,7 +2,6 @@ import app from './src/app';
 import MessageService from './src/message-service';
 import ScreenSnippet from './src/screen-snippet';
 import Window from './src/window';
-import './src/interface';
 
 export {
   app,

--- a/packages/api-browser/tsconfig.json
+++ b/packages/api-browser/tsconfig.json
@@ -13,7 +13,8 @@
         "allowSyntheticDefaultImports": true,
         "target": "es5"
     },
-    "files": [
-        "./preload.ts"
+    "include": [
+        "./preload.ts",
+        "node_modules/containerjs-api-specification/interface.ts"
     ]
 }

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "rimraf dist transpiled && tsc && rollup -c && rimraf transpiled",
-    "test": "npm run build",
-    "postinstall": "copyfiles -f \"node_modules/containerjs-api-specification/interface.ts\" src/ && npm run build"
+    "test": "npm run build"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/api-electron/preload.ts
+++ b/packages/api-electron/preload.ts
@@ -3,7 +3,6 @@ import app from './src/preload/app';
 import MessageService from './src/preload/message-service';
 import ScreenSnippet from './src/preload/screen-snippet';
 import Window from './src/preload/window';
-import './src/interface';
 
 export {
   app,

--- a/packages/api-electron/tsconfig.json
+++ b/packages/api-electron/tsconfig.json
@@ -13,7 +13,8 @@
         "allowSyntheticDefaultImports": true,
         "target": "es5"
     },
-    "files": [
-        "./preload.ts"
+    "include": [
+        "./preload.ts",
+        "node_modules/containerjs-api-specification/interface.ts"
     ]
 }

--- a/packages/api-openfin/package.json
+++ b/packages/api-openfin/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "rimraf dist transpiled && tsc && copyfiles -f src/notification.html dist && rollup -c && rimraf transpiled",
-    "test": "npm run build",
-    "postinstall": "copyfiles -f \"node_modules/containerjs-api-specification/interface.ts\" src/ && npm run build"
+    "test": "npm run build"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/api-openfin/preload.ts
+++ b/packages/api-openfin/preload.ts
@@ -3,7 +3,6 @@ import app from './src/app';
 import MessageService from './src/message-service';
 import ScreenSnippet from './src/screen-snippet';
 import Window from './src/window';
-import './src/interface';
 
 export {
   app,

--- a/packages/api-openfin/tsconfig.json
+++ b/packages/api-openfin/tsconfig.json
@@ -13,7 +13,8 @@
         "allowSyntheticDefaultImports": true,
         "target": "es5"
     },
-    "files": [
-        "./preload.ts"
+    "include": [
+        "./preload.ts",
+        "node_modules/containerjs-api-specification/interface.ts"
     ]
 }


### PR DESCRIPTION
As a general observation, ContainerJS has quite a few postinstall steps that copy files around. These can make things pretty confusing! 

This eliminates one of those steps, by configuring TypeScript to look in the `node_modules/containerjs-api-specification` folder.