### PR TITLE
Improved running of gh-pages locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,3 @@ transpiled/
 
 #gh-pages
 /docs/_site
-/docs/Gemfile.lock

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,2 +1,0 @@
-source 'http://rubygems.org'
-gem 'github-pages', group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+baseurl: '/ContainerJS'


### PR DESCRIPTION
To run gh-pages locally, use `jekyll serve` and navigate to `http://localhost:4000/ContainerJS`

Closes #156.