### PR TITLE
Change check for environment variable in test script

### DIFF
--- a/deploy-script.ps1
+++ b/deploy-script.ps1
@@ -1,4 +1,4 @@
-IF ($env:APPVEYOR_REPO_BRANCH -eq "master" -And $env:APPVEYOR_PULL_REQUEST_NUMBER -eq "") {
+IF ($env:APPVEYOR_REPO_BRANCH -eq "master" -And (-Not (Test-Path Env:\APPVEYOR_PULL_REQUEST_NUMBER))) {
   Write-Host "Publishing docs to gh-pages"
   git config --global credential.helper store
   Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:access_token):x-oauth-basic@github.com`n"

--- a/test-script.ps1
+++ b/test-script.ps1
@@ -3,7 +3,7 @@ npm --version
 npm run test
 
 # Don't run tests on PRs
-IF ($env:APPVEYOR_REPO_BRANCH -eq "master" -And $env:APPVEYOR_PULL_REQUEST_NUMBER -eq "") {
+IF ($env:APPVEYOR_REPO_BRANCH -eq "master" -And (-Not (Test-Path Env:\APPVEYOR_PULL_REQUEST_NUMBER))) {
   npm run test:ci
   npm run docs
 }


### PR DESCRIPTION
The previous check for a PR build number always failed. This corrects the problem