### PR TITLE
Update interface to include more types and comments

### DIFF
--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -22,6 +22,7 @@ class Window {
   children: any;
   innerWindow: any;
   eventListeners: any;
+  id: string;
 
   constructor(options, callback, errorCallback) {
     this.children = [];
@@ -30,11 +31,13 @@ class Window {
 
     if (!options) {
       this.innerWindow = window;
+      this.id = window.name;
       if (callback) {
         callback();
       }
     } else {
       this.innerWindow = window.open(options.url, options.name, objectToFeaturesString(options));
+      this.id = this.innerWindow.name;
       this.innerWindow.onclose = () => {
         removeAccessibleWindow(this.innerWindow.name);
       };

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -10,7 +10,7 @@ import { IpcMessages } from '../common/constants';
 let currentWindow = null;
 
 class Window implements ssf.Window {
-  innerWindow: any;
+  innerWindow: Electron.BrowserWindow;
   id: string;
 
   constructor(options: ssf.WindowOptions, callback, errorCallback) {
@@ -21,7 +21,7 @@ class Window implements ssf.Window {
 
     if (!options) {
       this.innerWindow = remote.getCurrentWindow();
-      this.id = this.innerWindow.id;
+      this.id = String(this.innerWindow.id);
       if (callback) {
         callback(this);
       }
@@ -75,11 +75,11 @@ class Window implements ssf.Window {
   }
 
   getParentWindow() {
-    return this.asPromise<Window>(this.innerWindow.getParentWindow).then((win) => {
+    return this.asPromise<Electron.BrowserWindow>(this.innerWindow.getParentWindow).then((win) => {
       if (win) {
         const parentWin = new Window(null, null, null);
         parentWin.innerWindow = win;
-        parentWin.id = win.id;
+        parentWin.id = String(win.id);
         return parentWin;
       }
       return null;

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -115,6 +115,7 @@ class Window implements ssf.Window {
   children: Array<any>;
   eventListeners: Map<any, any>;
   innerWindow: fin.OpenFinWindow;
+  id: string;
 
   constructor(options: ssf.WindowOptions, callback?: any, errorCallback?: any) {
     this.children = [];
@@ -129,6 +130,7 @@ class Window implements ssf.Window {
 
     if (!options) {
       this.innerWindow = fin.desktop.Window.getCurrent();
+      this.id = `${this.innerWindow.uuid}:${this.innerWindow.name}`;
       if (callback) {
         callback(this);
       }
@@ -140,7 +142,8 @@ class Window implements ssf.Window {
     if (openFinOptions.child) {
       const currentWindow = Window.getCurrentWindow();
       currentWindow.children.push(this);
-      this.innerWindow = new fin.desktop.Window(openFinOptions, (win) => {
+      this.innerWindow = new fin.desktop.Window(openFinOptions, () => {
+        this.id = `${this.innerWindow.uuid}:${this.innerWindow.name}`;
         // We want to return our window, not the OpenFin window
         if (callback) {
           callback(this);
@@ -157,6 +160,7 @@ class Window implements ssf.Window {
       const app = new fin.desktop.Application(appOptions, (successObject) => {
         app.run();
         this.innerWindow = app.getWindow();
+        this.id = `${this.innerWindow.uuid}:${this.innerWindow.name}`;
         if (callback) {
           callback(this);
         }
@@ -213,7 +217,7 @@ class Window implements ssf.Window {
   }
 
   getId() {
-    return `${this.innerWindow.uuid}:${this.innerWindow.name}`;
+    return this.id;
   }
 
   getMaximumSize() {

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -1,12 +1,6 @@
 let currentWindow = null;
 import MessageService from './message-service';
 
-declare namespace fin {
-  interface OpenFinWindow {
-    uuid: string;
-  }
-}
-
 const eventMap = {
   'auth-requested': 'auth-requested',
   'blur': 'blurred',
@@ -120,7 +114,7 @@ const convertOptions = (options: ssf.WindowOptions) => {
 class Window implements ssf.Window {
   children: Array<any>;
   eventListeners: Map<any, any>;
-  innerWindow: any;
+  innerWindow: fin.OpenFinWindow;
 
   constructor(options: ssf.WindowOptions, callback?: any, errorCallback?: any) {
     this.children = [];
@@ -146,7 +140,7 @@ class Window implements ssf.Window {
     if (openFinOptions.child) {
       const currentWindow = Window.getCurrentWindow();
       currentWindow.children.push(this);
-      this.innerWindow = new fin.desktop.Window(openFinOptions, () => {
+      this.innerWindow = new fin.desktop.Window(openFinOptions, (win) => {
         // We want to return our window, not the OpenFin window
         if (callback) {
           callback(this);

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -4,6 +4,9 @@
 // Needed to access the browsers window object
 type BrowserWindow = Window;
 
+/**
+ * @ignore
+ */
 declare namespace fin {
   interface OpenFinWindow {
     uuid: string;

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -1,3 +1,15 @@
+/// <reference types="electron" />
+/// <reference types="openfin" />
+
+// Needed to access the browsers window object
+type BrowserWindow = Window;
+
+declare namespace fin {
+  interface OpenFinWindow {
+    uuid: string;
+  }
+}
+
 declare namespace ssf {
   interface Rectangle {
     x: number;
@@ -101,7 +113,7 @@ declare namespace ssf {
     /**
      * The native window for the platform the API is running on.
      */
-    innerWindow: any;
+    innerWindow: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow;
 
     /**
 

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -98,9 +98,14 @@ declare namespace ssf {
   }
 
   class Window {
+    /**
+     * The native window for the platform the API is running on.
+     */
     innerWindow: any;
 
     /**
+
+     * Create a new window.
      * @param opts A window options object
      * @param callback A callback that is called if the window creation succeeds
      * @param errorCallback A callback that is called if window creation fails
@@ -109,266 +114,265 @@ declare namespace ssf {
 
     /**
      * Removes focus from the window.
-     * @returns {Promise<void>} A promise which resolves to nothing when the function has completed.
      */
     blur(): Promise<void>;
 
     /**
      * Closes the window.
-     * @returns {Promise<void>} A promise which resolves to nothing when the function has completed.
+     * @returns A promise which resolves to nothing when the function has completed.
      */
     close(): Promise<void>;
 
     /**
      * Flashes the window's frame and taskbar icon.
-     * @param {boolean} flag - Flag to start or stop the window flashing.
-     * @returns {Promise<void>} A promise which resolves to nothing when the function has completed.
+     * @param flag - Flag to start or stop the window flashing.
+     * @returns A promise which resolves to nothing when the function has completed.
      */
     flashFrame(flag: boolean): Promise<void>;
 
     /**
      * Focuses the window.
-     * @returns {Promise<void>} A promise which resolves to nothing when the function has completed.
+     * @returns A promise which resolves to nothing when the function has completed.
      */
     focus(): Promise<void>;
 
     /**
      * Returns the bounds of the window.
-     * @returns {Promise<Rectangle>} A promise that resolves to an object specifying the bounds of the window.
+     * @returns A promise that resolves to an object specifying the bounds of the window.
      */
     getBounds(): Promise<Rectangle>;
 
     /**
      * Get the child windows of the window.
-     * @returns {Window[]} A promise that resolves to an array of child windows.
+     * @returns A promise that resolves to an array of child windows.
      */
     getChildWindows(): ReadonlyArray<any>;
 
     /**
-     * Gets the id of the current window.
-     * @returns {string} The window id.
+     * Gets the id of the window.
+     * @returns The window id.
      */
     getId(): string;
 
     /**
      * Get the maximum size of the window.
-     * @returns {Promise<Number[]>} A promise that resolves to an array containing the maximum width and height of the window.
+     * @returns A promise that resolves to an array containing the maximum width and height of the window.
      */
     getMaximumSize(): Promise<ReadonlyArray<number>>;
 
     /**
      * Get the minimum size of the window.
-     * @returns {Promise<Number[]>} A promise that resolves to an array containing the minimum width and height of the window.
+     * @returns A promise that resolves to an array containing the minimum width and height of the window.
      */
     getMinimumSize(): Promise<ReadonlyArray<number>>;
 
     /**
      * Get the parent of the window. Null will be returned if the window has no parent.
-     * @returns {Promise<Window>} The parent window.
+     * @returns The parent window.
      */
     getParentWindow(): Promise<Window>;
 
     /**
      * Get the position of the window.
-     * @returns {Promise<Number[]>} A promise that resolves to an array of integers containing the x and y coordinates of the window.
+     * @returns A promise that resolves to an array of integers containing the x and y coordinates of the window.
      */
     getPosition(): Promise<ReadonlyArray<number>>;
 
     /**
      * Get the width and height of the window.
-     * @returns {Promise<Number[]>} A promise that resolves to an array of integers containing the width and height of the window.
+     * @returns A promise that resolves to an array of integers containing the width and height of the window.
      */
     getSize(): Promise<ReadonlyArray<number>>;
 
     /**
      * Get the title of the window
-     * @returns {Promise<string>} The title of the window.
+     * @returns The title of the window.
      */
     getTitle(): Promise<string>;
 
     /**
      * Check if the window has a shadow.
-     * @returns {Promise<boolean>} A promise that resolves to a boolean stating if the window has a shadow.
+     * @returns A promise that resolves to a boolean stating if the window has a shadow.
      */
     hasShadow(): Promise<boolean>;
 
     /**
      * Hides the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the window has hidden.
+     * @returns A promise that resolves to nothing when the window has hidden.
      */
     hide(): Promise<void>;
 
     /**
      * Check if the window is always on top of all other windows.
-     * @returns {Promise<boolean>} A promise that resolves to a boolean stating if the window is always on top.
+     * @returns A promise that resolves to a boolean stating if the window is always on top.
      */
     isAlwaysOnTop(): Promise<boolean>;
 
     /**
      * Check if the window can be maximized.
-     * @returns {Promise<boolean>} A promise that resolves to a boolean stating if the window can be maximized.
+     * @returns A promise that resolves to a boolean stating if the window can be maximized.
      */
     isMaximizable(): Promise<boolean>;
 
     /**
      * Check if the window is currently maximized.
-     * @returns {Promise<boolean>} A promise that resolves to a boolean stating if the window is maximized.
+     * @returns A promise that resolves to a boolean stating if the window is maximized.
      */
     isMaximized(): Promise<boolean>;
 
     /**
      * Check if the window can be minimized.
-     * @returns {Promise<boolean>} A promise that resolves to a boolean stating if the window can be minimized.
+     * @returns A promise that resolves to a boolean stating if the window can be minimized.
      */
     isMinimizable(): Promise<boolean>;
 
     /**
      * Check if the window is currently minimized.
-     * @returns {Promise<boolean>} A promise that resolves to a boolean stating if the window is minimized.
+     * @returns A promise that resolves to a boolean stating if the window is minimized.
      */
     isMinimized(): Promise<boolean>;
 
     /**
      * Check if the window can be resized.
-     * @returns {Promise<boolean>} A promise that resolves to a boolean stating if the window can be resized.
+     * @returns A promise that resolves to a boolean stating if the window can be resized.
      */
     isResizable(): Promise<boolean>;
 
     /**
      * Load a new URL in the window.
-     * @param {string} url - The URL to load in the window.
-     * @returns {Promise<void>} A promise that resolves when the window method succeeds.
+     * @param url - The URL to load in the window.
+     * @returns A promise that resolves when the window method succeeds.
      */
     loadURL(url: string): Promise<void>;
 
     /**
      * Reload the window.
-     * @returns {Promise<void>} A promise that resolves when the window method succeeds.
+     * @returns A promise that resolves when the window method succeeds.
      */
     reload(): Promise<void>;
 
     /**
      * Restores the window to the previous state.
-     * @returns {Promise<void>} A promise that resolves to nothing when the window method succeeds.
+     * @returns A promise that resolves to nothing when the window method succeeds.
      */
     restore(): Promise<void>;
 
     /**
      * Sets the window to always be on top of other windows.
-     * @param {boolean} alwaysOnTop - Sets if the window is always on top.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option is set.
+     * @param alwaysOnTop - Sets if the window is always on top.
+     * @returns A promise that resolves to nothing when the option is set.
      */
     setAlwaysOnTop(alwaysOnTop: boolean): Promise<void>;
 
     /**
      * Sets the window to always be on top of other windows.
-     * @param {Rectangle} bounds - Sets the bounds of the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option is set.
+     * @param bounds - Sets the bounds of the window.
+     * @returns A promise that resolves to nothing when the option is set.
      */
     setBounds(bounds: Rectangle): Promise<void>;
 
     /**
      * Sets the window icon.
-     * @param {string} icon - The url to the image.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param icon - The url to the image.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setIcon(icon: string): Promise<void>;
 
     /**
      * Sets if the window can be maximized.
-     * @param {boolean} maximizable - Set if the window can be maximized.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param maximizable - Set if the window can be maximized.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setMaximizable(maximizable: boolean): Promise<void>;
 
     /**
      * Sets the windows maximum size.
-     * @param {Number} maxWidth - The maximum width of the window.
-     * @param {Number} maxHeight - The maximum height of the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param maxWidth - The maximum width of the window.
+     * @param maxHeight - The maximum height of the window.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setMaximumSize(maxWidth: number, maxHeight: number): Promise<void>;
 
     /**
      * Sets if the window can be minimized.
-     * @param {boolean} minimizable - Set if the window can be minimized.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param minimizable - Set if the window can be minimized.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setMinimizable(minimizable: boolean): Promise<void>;
 
     /**
      * Sets the windows minimum size.
-     * @param {Number} minWidth - The minimum width of the window.
-     * @param {Number} minHeight - The minimum height of the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param minWidth - The minimum width of the window.
+     * @param minHeight - The minimum height of the window.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setMinimumSize(minWidth: number, minHeight: number): Promise<void>;
 
     /**
      * Sets the windows position.
-     * @param {Number} x - The x position of the window.
-     * @param {Number} y - The y position of the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param x - The x position of the window.
+     * @param y - The y position of the window.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setPosition(x: number, y: number): Promise<void>;
 
     /**
      * Sets if the window is resizable.
-     * @param {boolean} resizable - If the window can be resized.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param resizable - If the window can be resized.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setResizable(resizable: boolean): Promise<void>;
 
     /**
      * Sets the width and height of the window.
-     * @param {number} width - The width of the window.
-     * @param {number} height - The height of the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param width - The width of the window.
+     * @param height - The height of the window.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setSize(width: number, height: number): Promise<void>;
 
     /**
      * Sets if the window is shown in the taskbar.
-     * @param {boolean} skipTaskbar - If the window is shown in the taskbar.
-     * @returns {Promise<void>} A promise that resolves to nothing when the option has been set.
+     * @param skipTaskbar - If the window is shown in the taskbar.
+     * @returns A promise that resolves to nothing when the option has been set.
      */
     setSkipTaskbar(skipTaskbar: boolean): Promise<void>;
 
     /**
      * Show the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the window is showing.
+     * @returns A promise that resolves to nothing when the window is showing.
      */
     show(): Promise<void>;
 
     /**
      * Maximize the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the window has maximized.
+     * @returns A promise that resolves to nothing when the window has maximized.
      */
     maximize(): Promise<void>;
 
     /**
      * Minimize the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the window has minimized.
+     * @returns A promise that resolves to nothing when the window has minimized.
      */
     minimize(): Promise<void>;
 
     /**
      * Unmaximize the window.
-     * @returns {Promise<void>} A promise that resolves to nothing when the window has unmaximized.
+     * @returns A promise that resolves to nothing when the window has unmaximized.
      */
     unmaximize(): Promise<void>;
 
     /**
      * Adds a listener for a particular window event.
-     * @param {string} event - The event to listen for.
-     * @param {function} listener - The function to call when the event fires.
+     * @param event - The event to listen for.
+     * @param listener - The function to call when the event fires.
      */
     addListener(event: string, listener: Function): void;
 
     /**
      * Removes an event listener from the window. The listener must be the same function that was passed into addListener.
-     * @param {string} event - The event the listener was listening for.
-     * @param {function} listener - The original function that was passed to addListener.
+     * @param event - The event the listener was listening for.
+     * @param listener - The original function that was passed to addListener.
      */
     removeListener(event: string, listener: Function): void;
 
@@ -379,39 +383,68 @@ declare namespace ssf {
 
     /**
      * Send a message to the window.
-     * @param {string|object} message - The message to send to the window. Can be any serializable object.
+     * @param message - The message to send to the window. Can be any serializable object.
      */
     postMessage(message: string | Object): void;
 
     /**
-   * Gets the current window object.
-   * @param {function} callback - Function that is called when the window is created successfully.
-   * @param {function} errorCallback - Function that is called when the window could not be created.
-   * @returns {Window} The window.
-   * @static
-   */
+     * Gets the current window object.
+     * @param callback - Function that is called when the window is created successfully.
+     * @param errorCallback - Function that is called when the window could not be created.
+     * @returns The window.
+     */
     static getCurrentWindow(callback: Function, errorCallback: Function): Window;
   }
 
   class MessageService {
+    /**
+     * @param windowId - The id of the window to send the message to.
+     * @param topic - The topic of the message.
+     * @param message - The message to send.
+     */
     static send(windowId: string, topic :string, message: string|object): void;
+
+    /**
+     * @param windowId - The id of the window to listen to messages fron. Can be a wildcard '*' to listen to all windows.
+     * @param topic - The topic to listen for.
+     * @param listener - The function to run when a message is received. The message is passed as a parameter to the function.
+     */
     static subscribe(windowId: string, topic :string, listener: Function): void;
+
+    /**
+     * @param windowId - The id of the window that the listener was subscribed to or the wildcard '*'.
+     * @param topic - The topic that was being listened to.
+     * @param listener - The function that was passed to subscribe. _Note:_ this must be the same function object.
+     */
     static unsubscribe(windowId: string, topic :string, listener: Function): void;
   }
 
   class ScreenSnippet {
+    /**
+     * Captures the current visible screen. Returns the image as a base64 encoded png string.
+     */
     capture(): Promise<string>;
   }
 
   class App {
+    /**
+     * A promise that resolves when the API has finished bootstrapping.
+     */
     static ready(): Promise<any>;
   }
 
   class NotificationOptions {
+    /**
+     * The text to display underneath the title text.
+     */
     body?: string;
   }
 }
 
 declare interface Window {
+  /**
+   * @param title - The title text of the notification.
+   * @param options - The notification options.
+   */
   Notification(title: string, options: ssf.NotificationOptions): void;
 }

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -419,6 +419,7 @@ declare namespace ssf {
 
   class MessageService {
     /**
+     * Send a message to a specific window
      * @param windowId - The id of the window to send the message to.
      * @param topic - The topic of the message.
      * @param message - The message to send.
@@ -426,6 +427,7 @@ declare namespace ssf {
     static send(windowId: string, topic :string, message: string|object): void;
 
     /**
+     * Subscribe to message from a window/topic
      * @param windowId - The id of the window to listen to messages fron. Can be a wildcard '*' to listen to all windows.
      * @param topic - The topic to listen for.
      * @param listener - The function to run when a message is received. The message is passed as a parameter to the function.
@@ -433,6 +435,7 @@ declare namespace ssf {
     static subscribe(windowId: string, topic :string, listener: Function): void;
 
     /**
+     * Unsubscribe from a window/topic
      * @param windowId - The id of the window that the listener was subscribed to or the wildcard '*'.
      * @param topic - The topic that was being listened to.
      * @param listener - The function that was passed to subscribe. _Note:_ this must be the same function object.
@@ -464,6 +467,7 @@ declare namespace ssf {
 
 declare interface Window {
   /**
+   * Create a notification
    * @param title - The title text of the notification.
    * @param options - The notification options.
    */

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -110,6 +110,12 @@ declare namespace ssf {
   }
 
   class Window {
+
+    /**
+     * The id that uniquely identifies the window
+     */
+    id: string
+
     /**
      * The native window for the platform the API is running on.
      */

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -19,6 +19,8 @@
     "typedoc-markdown-theme": "0.0.4"
   },
   "dependencies": {
-    "bootstrap": "^3.3.7"
+    "bootstrap": "^3.3.7",
+    "@types/electron": "^1.4.38",
+    "@types/openfin": "^17.0.2"
   }
 }


### PR DESCRIPTION
Aside from fixing some of the types, I changed the documentation generation script to look for `@ignore` tags. This allows us to ignore parts of the interface in the documentation, in this case to ignore the extension to add `uuid` to the OpenFin window object. This might be useful to include with the changes to documentation in  #165 as well.