### PR TITLE
bumped version number

### DIFF
--- a/packages/api-demo/package.json
+++ b/packages/api-demo/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/symphonyoss/ContainerJS#readme",
   "dependencies": {
-    "containerjs-api-bundle": "^0.0.1",
-    "containerjs-api-electron": "^0.0.1",
+    "containerjs-api-bundle": "0.0.2",
+    "containerjs-api-electron": "0.0.2",
     "openfin-cli": "^1.1.5",
     "openfin-launcher": "^1.3.12"
   },

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-electron",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "module": "build/es/preload.js",

--- a/packages/api-tests/package.json
+++ b/packages/api-tests/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "assert": "^1.4.1",
-    "containerjs-api-electron": "0.0.1",
+    "containerjs-api-electron": "0.0.2",
     "containerjs-api-openfin": "0.0.2",
     "electron": "^1.6.6",
     "live-server": "^1.2.0",


### PR DESCRIPTION
Currently `npm i containerjs-api-electron` fails because it depends on `containerjs-api-specification` 0.0.1, which has a failing post install step (yuck!)

This just bumps the version number so that I can release these fixes:

https://github.com/symphonyoss/ContainerJS/pull/185

After this, I am NOT doing any more manual versioning. It's horrible ;-)