### PR TITLE
Fix AppVeyor test setup to fail build when tests fail

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,9 @@ install:
   - appveyor-retry npm install
 
 test_script:
+  - node --version
+  - npm --version
+  - npm test
   - ps: .\test-script.ps1
 
 

--- a/test-script.ps1
+++ b/test-script.ps1
@@ -1,7 +1,3 @@
-node --version
-npm --version
-npm run test
-
 # Don't run tests on PRs
 IF ($env:APPVEYOR_REPO_BRANCH -eq "master" -And (-Not (Test-Path Env:\APPVEYOR_PULL_REQUEST_NUMBER))) {
   npm run test:ci


### PR DESCRIPTION
Ensure that the AppVeyor  build fails if `npm [run] test`  fails.

Fixes #177.