### PR TITLE
Update scripts across packages for consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "4"
   - "6"
   - "7"
+script:
+  - npm run ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,9 @@ install:
   - appveyor-retry npm install
 
 test_script:
+  - node --version
+  - npm --version
+  - npm run ci
   - ps: .\test-script.ps1
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "postinstall": "npm run bootstrap",
     "test:ui": "cd packages/api-tests && npm run test:ui",
     "test:ci": "cd packages/api-tests && npm run test:ci && node generate-test-report.js",
-    "docs": "cd packages/api-specification && npm run docs"
+    "docs": "cd packages/api-specification && npm run docs",
+    "ci": "npm test && npm run build"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/api-browser/package.json
+++ b/packages/api-browser/package.json
@@ -11,8 +11,7 @@
     "build": "npm run clean && npm run build:cjs && npm run build:es && rollup -c",
     "build:es": "rimraf build/es && tsc -p tsconfig.json -m ES2015 --outdir ./build/es",
     "build:cjs": "rimraf build/lib && tsc -p tsconfig.json -m CommonJS --outdir ./build/lib",
-    "build:umd": "rimraf build/dist && npm run build:es && rollup -c",
-    "test": "npm run build"
+    "build:umd": "rimraf build/dist && npm run build:es && rollup -c"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/api-bundle/package.json
+++ b/packages/api-bundle/package.json
@@ -4,7 +4,6 @@
   "description": "A bundle of containerJS APIs",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\"",
     "build": "rollup -c",
     "prepublish": "copyfiles -f node_modules/containerjs-api-openfin/src/notification.html build"
   },

--- a/packages/api-demo/package.json
+++ b/packages/api-demo/package.json
@@ -10,8 +10,7 @@
     "electron": "npm-run-all --parallel launch:electron serve:no-browser",
     "launch:openfin": "openfin --launch --config ./src/app.json",
     "openfin": "npm-run-all --parallel launch:openfin serve:no-browser",
-    "browser": "npm run serve",
-    "test": "echo \"Error: no test specified\""
+    "browser": "npm run serve"
   },
   "repository": {
     "type": "git",

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -10,8 +10,7 @@
     "clean": "rimraf build",
     "build": "npm run clean && npm run build:es && rollup -c",
     "build:es": "rimraf build/es && tsc",
-    "build:umd": "rimraf build/dist && npm run build:es && rollup -c",
-    "test": "npm run build"
+    "build:umd": "rimraf build/dist && npm run build:es && rollup -c"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/api-openfin/package.json
+++ b/packages/api-openfin/package.json
@@ -11,8 +11,7 @@
     "build": "npm run clean && npm run build:cjs && npm run build:es && rollup -c && copyfiles -f src/notification.html ./build/dist",
     "build:es": "rimraf build/es && tsc -p tsconfig.json -m ES2015 --outdir ./build/es && copyfiles -f src/notification.html ./build/es",
     "build:cjs": "rimraf build/lib && tsc -p tsconfig.json -m CommonJS --outdir ./build/lib && copyfiles -f src/notification.html ./build/lib",
-    "build:umd": "rimraf build/dist && npm run build:es && rollup -c && copyfiles -f src/notification.html ./build/dist",
-    "test": "npm run build"
+    "build:umd": "rimraf build/dist && npm run build:es && rollup -c && copyfiles -f src/notification.html ./build/dist"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No test specified\" && exit 0",
     "typedoc2html": "node transform-type-info.js --testfile test-report.json --outpath ../../docs",
     "typedoc": "typedoc --mode file --json type-info.json interface.ts",
     "docs": "npm run typedoc && npm run typedoc2html"

--- a/test-script.ps1
+++ b/test-script.ps1
@@ -1,7 +1,3 @@
-node --version
-npm --version
-npm run test
-
 # Don't run tests on PRs
 IF ($env:APPVEYOR_REPO_BRANCH -eq "master" -And (-Not (Test-Path Env:\APPVEYOR_PULL_REQUEST_NUMBER))) {
   npm run test:ci


### PR DESCRIPTION
- Simplify npm scripts
- Remove `test` tasks that, inconsistently, either printed a message or ran the build (rather than actually running any tests)
- Ensure all `build` tasks are run on CI (this wasn't happening for `api-bundle`)

This also fixes #177, so feel free to merge this instead of #190.