### PR TITLE
WIP: Change Electron to use window.open

### DIFF
--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -23,6 +23,7 @@ class Window {
   innerWindow: any;
   eventListeners: any;
   id: string;
+  globalWindow: any;
 
   constructor(options, callback, errorCallback) {
     this.children = [];
@@ -31,12 +32,14 @@ class Window {
 
     if (!options) {
       this.innerWindow = window;
+      this.globalWindow = this.innerWindow;
       this.id = window.name;
       if (callback) {
         callback();
       }
     } else {
       this.innerWindow = window.open(options.url, options.name, objectToFeaturesString(options));
+      this.globalWindow = this.innerWindow;
       this.id = this.innerWindow.name;
       this.innerWindow.onclose = () => {
         removeAccessibleWindow(this.innerWindow.name);

--- a/packages/api-demo/package.json
+++ b/packages/api-demo/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/symphonyoss/ContainerJS#readme",
   "dependencies": {
-    "containerjs-api-bundle": "^0.0.1",
-    "containerjs-api-electron": "^0.0.1",
+    "containerjs-api-bundle": "0.0.2",
+    "containerjs-api-electron": "0.0.2",
     "openfin-cli": "^1.1.5",
     "openfin-launcher": "^1.3.12"
   },

--- a/packages/api-demo/src/window/window-api-demo.js
+++ b/packages/api-demo/src/window/window-api-demo.js
@@ -60,8 +60,8 @@ appReady.then(() => {
         addListItem('focus');
       });
 
-      win.addListener('close', () => {
-        addListItem('close');
+      win.addListener('closed', () => {
+        addListItem('closed');
       });
     });
   };

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-electron",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "module": "build/es/preload.js",

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -12,6 +12,7 @@ let currentWindow = null;
 class Window implements ssf.Window {
   innerWindow: Electron.BrowserWindow;
   id: string;
+  globalWindow: any;
 
   constructor(options: ssf.WindowOptions, callback, errorCallback) {
     MessageService.subscribe('*', 'ssf-window-message', (...args) => {
@@ -21,6 +22,7 @@ class Window implements ssf.Window {
 
     if (!options) {
       this.innerWindow = remote.getCurrentWindow();
+      this.globalWindow = window;
       this.id = String(this.innerWindow.id);
       if (callback) {
         callback(this);
@@ -29,13 +31,20 @@ class Window implements ssf.Window {
     }
 
     const features = Object.assign({}, options, { title: options.name });
+    // Object.keys(features).forEach(key => {
+    //   if (typeof features[key] === 'boolean') {
+    //     features[key] = features[key] ? 'yes' : 'no';
+    //   }
+    // });
 
-    this.id = ipc.sendSync(IpcMessages.IPC_SSF_NEW_WINDOW, {
-      url: features.url,
-      name: features.name,
-      features
-    });
-    this.innerWindow = BrowserWindow.fromId(parseInt(this.id));
+    // (features as any).left = features.x;
+    // delete features.x;
+    // (features as any).top = features.y;
+    // delete features.y;
+
+    const win = window.open(features.url, features.name, JSON.stringify(features));
+    this.innerWindow = (win as any).ssf.Window.getCurrentWindow().innerWindow;
+    this.globalWindow = win;
 
     if (callback) {
       callback(this);

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -116,6 +116,7 @@ class Window implements ssf.Window {
   eventListeners: Map<any, any>;
   innerWindow: fin.OpenFinWindow;
   id: string;
+  globalWindow: any;
 
   constructor(options: ssf.WindowOptions, callback?: any, errorCallback?: any) {
     this.children = [];
@@ -130,6 +131,7 @@ class Window implements ssf.Window {
 
     if (!options) {
       this.innerWindow = fin.desktop.Window.getCurrent();
+      this.globalWindow = window;
       this.id = `${this.innerWindow.uuid}:${this.innerWindow.name}`;
       if (callback) {
         callback(this);
@@ -144,6 +146,7 @@ class Window implements ssf.Window {
       currentWindow.children.push(this);
       this.innerWindow = new fin.desktop.Window(openFinOptions, () => {
         this.id = `${this.innerWindow.uuid}:${this.innerWindow.name}`;
+        this.globalWindow = this.innerWindow.getNativeWindow();
         // We want to return our window, not the OpenFin window
         if (callback) {
           callback(this);
@@ -160,6 +163,7 @@ class Window implements ssf.Window {
       const app = new fin.desktop.Application(appOptions, (successObject) => {
         app.run();
         this.innerWindow = app.getWindow();
+        this.globalWindow = this.innerWindow.getNativeWindow();
         this.id = `${this.innerWindow.uuid}:${this.innerWindow.name}`;
         if (callback) {
           callback(this);

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -125,6 +125,11 @@ declare namespace ssf {
     innerWindow: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow;
 
     /**
+     * The global window object for the referenced window.
+     */
+    globalWindow: any;
+
+    /**
 
      * Create a new window.
      * @param opts A window options object


### PR DESCRIPTION
This is a work in progress for changing the Electron API to use window.open. This is so child windows are created in the same process as their parent, therefore allowing access to each others JavaScript context.

WIP because features string doesn't work yet, meaning tests also fail.