### PR TITLE
Force add docs folder in deploy script

### DIFF
--- a/deploy-script.ps1
+++ b/deploy-script.ps1
@@ -4,7 +4,7 @@ IF ($env:APPVEYOR_REPO_BRANCH -eq "master" -And (-Not (Test-Path Env:\APPVEYOR_P
   Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:access_token):x-oauth-basic@github.com`n"
   git config --global user.email $env:github_email
   git config --global user.name "ColinEberhardt"
-  git add .
+  git add -f docs
   git commit -m "Update gh-pages: $env:APPVEYOR_REPO_COMMIT_MESSAGE"
   git subtree split --prefix docs -b gh-pages
   git push -f origin gh-pages:gh-pages


### PR DESCRIPTION
The `Docs.html` file was being gitignored. This force adds the docs folder in the deploy script, meaning the file will now be added. Fixes 404 error in gh-pages.