### PR TITLE
Add git attributes file for ssf-electron binary

### DIFF
--- a/packages/api-electron/.gitattributes
+++ b/packages/api-electron/.gitattributes
@@ -1,1 +1,2 @@
-bin/ssf-electron text eol=crlf
+# Needed for running the executable on mac/linux
+bin/ssf-electron text eol=lf


### PR DESCRIPTION
Closes #196. It might be a good idea @ColinEberhardt to pull down this branch to make sure it fixes the problem. It seems to work fine on my machine with a fresh clone of the repo though :-)