### PR TITLE
Make windows implement most event emitter methods

### DIFF
--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -164,7 +164,7 @@ class Window implements ssf.WindowCore {
 
   listenerCount(event) {
     return this.eventListeners.has(event) ? this.eventListeners.get(event).length : 0;
-  }n
+  }
 
   listeners(event) {
     return this.eventListeners.get(event);
@@ -177,14 +177,7 @@ class Window implements ssf.WindowCore {
       listener();
     };
 
-    if (this.eventListeners.has(event)) {
-      const temp = this.eventListeners.get(event);
-      temp.push(listener);
-      this.eventListeners.set(event, temp);
-    } else {
-      this.eventListeners.set(event, [unsubscribeListener]);
-    }
-    this.innerWindow.addEventListener(eventMap[event], unsubscribeListener);
+    this.on(event, unsubscribeListener);
     return this;
   }
 

--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -14,7 +14,7 @@ const getWindowOffsets = (win) => {
 class Window implements ssf.WindowCore {
   children: ssf.Window[];
   innerWindow: any;
-  eventListeners: any;
+  eventListeners: Map<string, ((...args: any[]) => void)[]> = new Map();
   id: string;
 
   constructor(options, callback?, errorCallback?) {

--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -172,9 +172,9 @@ class Window implements ssf.WindowCore {
 
   once(event, listener) {
     // Remove the listener once it is called
-    const unsubscribeListener = () => {
+    const unsubscribeListener = (evt) => {
       this.removeListener(event, unsubscribeListener);
-      listener();
+      listener(evt);
     };
 
     this.on(event, unsubscribeListener);

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -243,14 +243,39 @@ class Window implements ssf.Window {
 
   addListener(event, listener) {
     this.innerWindow.addListener(event, listener);
+    return this;
+  }
+
+  on(event, listener) {
+    this.innerWindow.on(event, listener);
+    return this;
+  }
+
+  eventNames() {
+    return this.innerWindow.eventNames() as string[];
+  }
+
+  listenerCount(event) {
+    return this.innerWindow.listenerCount(event);
+  }
+
+  listeners(event) {
+    return this.innerWindow.listeners(event);;
+  }
+
+  once(event, listener) {
+    this.innerWindow.once(event, listener);
+    return this;
   }
 
   removeListener(event, listener) {
     this.innerWindow.removeListener(event, listener);
+    return this;
   }
 
-  removeAllListeners() {
-    this.innerWindow.removeAllListeners();
+  removeAllListeners(eventName) {
+    this.removeAllListeners(eventName);
+    return this;
   }
 
   postMessage(message) {

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -242,47 +242,6 @@ class Window implements ssf.Window {
     });
   }
 
-  // addListener(event, listener) {
-  //   this.innerWindow.addListener(event, listener);
-  //   return this;
-  // }
-
-  // on(event, listener) {
-  //   this.innerWindow.on(event, listener);
-  //   return this;
-  // }
-
-  // eventNames() {
-  //   // Use our own listeners array so we can remove the remoteFunction listeners
-  //   return this.innerWindow.eventNames().filter(name => this.listeners(name).length > 0);
-  // }
-
-  // listenerCount(event) {
-  //   // Use our own listeners array so we can remove the remoteFunction listeners
-  //   return this.listeners(event).length;
-  // }
-
-  // listeners(event) {
-  //   // Each electron event already has a handler associated with it due to the
-  //   // remote module. We dont want to expose this, so we filter it out
-  //   return this.innerWindow.listeners(event).filter(l => l.name !== 'remoteFunction');
-  // }
-
-  // once(event, listener) {
-  //   this.innerWindow.once(event, listener);
-  //   return this;
-  // }
-
-  // removeListener(event, listener) {
-  //   this.innerWindow.removeListener(event, listener);
-  //   return this;
-  // }
-
-  // removeAllListeners(eventName) {
-  //   this.innerWindow.removeAllListeners(eventName);
-  //   return this;
-  // }
-
   addListener(event, listener) {
     if (this.eventListeners.has(event)) {
       const temp = this.eventListeners.get(event);

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -13,7 +13,7 @@ const isUrlPattern = /^https?:\/\//i;
 class Window implements ssf.Window {
   innerWindow: Electron.BrowserWindow;
   id: string;
-  eventListeners: Map<string, Function[]> = new Map();
+  eventListeners: Map<string, ((...args: any[]) => void)[]> = new Map();
 
   constructor(options: ssf.WindowOptions, callback, errorCallback) {
     MessageService.subscribe('*', 'ssf-window-message', (...args) => {

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -272,9 +272,9 @@ class Window implements ssf.Window {
 
   once(event, listener) {
     // Remove the listener once it is called
-    const unsubscribeListener = () => {
+    const unsubscribeListener = (evt) => {
       this.removeListener(event, unsubscribeListener);
-      listener();
+      listener(evt);
     };
 
     this.on(event, unsubscribeListener);

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -467,9 +467,9 @@ class Window implements ssf.Window {
 
   once(event, listener) {
     // Remove the listener once it is called
-    const unsubscribeListener = () => {
+    const unsubscribeListener = (evt) => {
       this.removeListener(event, unsubscribeListener);
-      listener();
+      listener(evt);
     };
 
     this.on(event, unsubscribeListener);

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -472,14 +472,7 @@ class Window implements ssf.Window {
       listener();
     };
 
-    if (this.eventListeners.has(event)) {
-      const temp = this.eventListeners.get(event);
-      temp.push(listener);
-      this.eventListeners.set(event, temp);
-    } else {
-      this.eventListeners.set(event, [unsubscribeListener]);
-    }
-    this.innerWindow.addEventListener(eventMap[event], unsubscribeListener);
+    this.on(event, unsubscribeListener);
     return this;
   }
 

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -446,6 +446,41 @@ class Window implements ssf.Window {
       this.eventListeners.set(event, [listener]);
     }
     this.innerWindow.addEventListener(eventMap[event], listener);
+    return this;
+  }
+
+  on(event, listener) {
+    return this.addListener(event, listener);
+  }
+
+  eventNames() {
+    return Array.from(this.eventListeners.keys());
+  }
+
+  listenerCount(event) {
+    return this.eventListeners.has(event) ? this.eventListeners.get(event).length : 0;
+  }
+
+  listeners(event) {
+    return this.eventListeners.get(event);
+  }
+
+  once(event, listener) {
+    // Remove the listener once it is called
+    const unsubscribeListener = () => {
+      this.removeListener(event, unsubscribeListener);
+      listener();
+    };
+
+    if (this.eventListeners.has(event)) {
+      const temp = this.eventListeners.get(event);
+      temp.push(listener);
+      this.eventListeners.set(event, temp);
+    } else {
+      this.eventListeners.set(event, [unsubscribeListener]);
+    }
+    this.innerWindow.addEventListener(eventMap[event], unsubscribeListener);
+    return this;
   }
 
   removeListener(event, listener) {
@@ -453,22 +488,34 @@ class Window implements ssf.Window {
       let listeners = this.eventListeners.get(event);
       let index = listeners.indexOf(listener);
       if (index >= 0) {
-        listeners = listeners.splice(index, 1);
-        this.eventListeners.set(event, listeners);
+        listeners.splice(index, 1);
+        listeners.length > 0
+          ? this.eventListeners.set(event, listeners)
+          : this.eventListeners.delete(event);
       }
     }
 
     this.innerWindow.removeEventListener(eventMap[event], listener);
+    return this;
   }
 
-  removeAllListeners() {
-    this.eventListeners.forEach((value, key) => {
-      value.forEach((listener) => {
-        this.innerWindow.removeEventListener(key, listener);
-      });
-    });
+  removeAllListeners(eventName) {
+    const removeAllListenersForEvent = (event) => {
+      if (this.eventListeners.has(event)) {
+        this.eventListeners.get(event).forEach((listener) => {
+          this.innerWindow.removeEventListener(eventMap[event], listener);
+        });
+        this.eventListeners.delete(event);
+      }
+    };
 
-    this.eventListeners.clear();
+    if (eventName) {
+      removeAllListenersForEvent(eventName);
+    } else {
+      this.eventListeners.forEach((value, key) => removeAllListenersForEvent(key));
+    }
+
+    return this;
   }
 
   postMessage(message) {

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -129,7 +129,7 @@ const convertOptions = (options: ssf.WindowOptions) => {
 };
 
 class Window implements ssf.Window {
-  eventListeners: Map<any, any>;
+  eventListeners: Map<string, ((...args: any[]) => void)[]> = new Map();
   innerWindow: fin.OpenFinWindow;
   id: string;
 

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -134,7 +134,6 @@ class Window implements ssf.Window {
   id: string;
 
   constructor(options: ssf.WindowOptions, callback?: any, errorCallback?: any) {
-    this.eventListeners = new Map();
     MessageService.subscribe('*', 'ssf-window-message', (...args) => {
       const event = 'message';
       if (this.eventListeners.has(event)) {

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -117,6 +117,59 @@ declare namespace ssf {
     transparent?: boolean;
   }
 
+  class EventEmitter {
+    /**
+     * Adds a lister that runs when the specified event occurs. Alias for <span class="code">on()</span>.
+     * @param event The event to listen for.
+     * @param listener The function to run when the event occurs.
+     */
+    addListener(event: WindowEvent, listener: Function): EventEmitter;
+
+    /**
+     * Adds a lister that runs when the specified event occurs. Alias for <span class="code">addListener()</span>.
+     * @param event The event to listen for.
+     * @param listener The function to run when the event occurs.
+     */
+    on(event: WindowEvent, listener: Function): EventEmitter;
+
+    /**
+     * Adds a lister that runs once when the specified event occurs, then is removed.
+     * @param event The event to listen for.
+     * @param listener The function to run once when the event occurs.
+     */
+    once(event: WindowEvent, listener: Function): EventEmitter;
+
+    /**
+     * Get all event names with active listeners.
+     */
+    eventNames(): string[];
+
+    /**
+     * Get the number of listeners currently listening for an event.
+     * @param event The event to get the number of listeners for.
+     */
+    listenerCount(event: WindowEvent): number;
+
+    /**
+     * Get all listeners for an event.
+     * @param event The event to get the listeners for.
+     */
+    listeners(event: WindowEvent): Function[];
+
+    /**
+     * Remove a listener from an event.
+     * @param event The event to remove the listener from.
+     * @param listener The listener to remove. Must be the same object that was passed to <span class="code">addListener()</span>
+     */
+    removeListener(event: WindowEvent, listener: Function): EventEmitter;
+
+    /**
+     * Removes all listeners from a given event, or all events if no event is passed.
+     * @param event The event to remove the listeners from.
+     */
+    removeAllListeners(event?: WindowEvent): EventEmitter;
+  }
+
   interface WindowEvent {
     /** Fires when the window has been blurred */
     blur: 'blur';
@@ -149,7 +202,7 @@ declare namespace ssf {
     show: 'show';
   }
 
-  class WindowCore {
+  abstract class WindowCore extends EventEmitter {
     /**
      * The id that uniquely identifies the window
      */
@@ -287,25 +340,6 @@ declare namespace ssf {
      * @param message - The message to send to the window. Can be any serializable object.
      */
     postMessage(message: string | Object): void;
-
-    /**
-     * Adds a listener for a particular window event.
-     * @param event - The event to listen for.
-     * @param listener - The function to call when the event fires.
-     */
-    addListener(event: string, listener: Function): void;
-
-    /**
-     * Removes an event listener from the window. The listener must be the same function that was passed into addListener.
-     * @param event - The event the listener was listening for.
-     * @param listener - The original function that was passed to addListener.
-     */
-    removeListener(event: string, listener: Function): void;
-
-    /**
-     * Removes all listeners from all window events.
-     */
-    removeAllListeners(): void;
 
     /**
      * Gets the current window object.

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -119,21 +119,21 @@ declare namespace ssf {
 
   class EventEmitter {
     /**
-     * Adds a lister that runs when the specified event occurs. Alias for <span class="code">on()</span>.
+     * Adds a listener that runs when the specified event occurs. Alias for <span class="code">on()</span>.
      * @param event The event to listen for.
      * @param listener The function to run when the event occurs.
      */
     addListener(event: string, listener: Function): EventEmitter;
 
     /**
-     * Adds a lister that runs when the specified event occurs. Alias for <span class="code">addListener()</span>.
+     * Adds a listener that runs when the specified event occurs. Alias for <span class="code">addListener()</span>.
      * @param event The event to listen for.
      * @param listener The function to run when the event occurs.
      */
     on(event: string, listener: Function): EventEmitter;
 
     /**
-     * Adds a lister that runs once when the specified event occurs, then is removed.
+     * Adds a listener that runs once when the specified event occurs, then is removed.
      * @param event The event to listen for.
      * @param listener The function to run once when the event occurs.
      */

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -142,7 +142,7 @@ declare namespace ssf {
     /**
      * Get all event names with active listeners.
      */
-    eventNames(): string[];
+    eventNames(): (string|symbol)[];
 
     /**
      * Get the number of listeners currently listening for an event.

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -202,7 +202,7 @@ declare namespace ssf {
     show: 'show';
   }
 
-  abstract class WindowCore extends EventEmitter {
+  class WindowCore extends EventEmitter {
     /**
      * The id that uniquely identifies the window
      */

--- a/packages/api-specification/interface.ts
+++ b/packages/api-specification/interface.ts
@@ -123,21 +123,21 @@ declare namespace ssf {
      * @param event The event to listen for.
      * @param listener The function to run when the event occurs.
      */
-    addListener(event: WindowEvent, listener: Function): EventEmitter;
+    addListener(event: string, listener: Function): EventEmitter;
 
     /**
      * Adds a lister that runs when the specified event occurs. Alias for <span class="code">addListener()</span>.
      * @param event The event to listen for.
      * @param listener The function to run when the event occurs.
      */
-    on(event: WindowEvent, listener: Function): EventEmitter;
+    on(event: string, listener: Function): EventEmitter;
 
     /**
      * Adds a lister that runs once when the specified event occurs, then is removed.
      * @param event The event to listen for.
      * @param listener The function to run once when the event occurs.
      */
-    once(event: WindowEvent, listener: Function): EventEmitter;
+    once(event: string, listener: Function): EventEmitter;
 
     /**
      * Get all event names with active listeners.
@@ -148,26 +148,26 @@ declare namespace ssf {
      * Get the number of listeners currently listening for an event.
      * @param event The event to get the number of listeners for.
      */
-    listenerCount(event: WindowEvent): number;
+    listenerCount(event: string): number;
 
     /**
      * Get all listeners for an event.
      * @param event The event to get the listeners for.
      */
-    listeners(event: WindowEvent): Function[];
+    listeners(event: string): Function[];
 
     /**
      * Remove a listener from an event.
      * @param event The event to remove the listener from.
      * @param listener The listener to remove. Must be the same object that was passed to <span class="code">addListener()</span>
      */
-    removeListener(event: WindowEvent, listener: Function): EventEmitter;
+    removeListener(event: string, listener: Function): EventEmitter;
 
     /**
      * Removes all listeners from a given event, or all events if no event is passed.
      * @param event The event to remove the listeners from.
      */
-    removeAllListeners(event?: WindowEvent): EventEmitter;
+    removeAllListeners(event?: string): EventEmitter;
   }
 
   interface WindowEvent {

--- a/packages/api-tests/test/test-helpers.js
+++ b/packages/api-tests/test/test-helpers.js
@@ -12,7 +12,7 @@ const selectWindow = (client, handle) => {
 const openNewWindow = (client, options) => {
   const script = (options, callback) => {
     ssf.app.ready().then(() => {
-      new ssf.Window(options, () => {
+      window.newWin = new ssf.Window(options, () => {
         callback();
       });
     });

--- a/packages/api-tests/test/window.core.spec.js
+++ b/packages/api-tests/test/window.core.spec.js
@@ -426,6 +426,132 @@ describe('WindowCore API', function(done) {
       return chainPromises(steps);
     });
 
+    it.only('Should remove a listener from the window #ssf.Window.removeListener #ssf.WindowCore.removeListener', function() {
+      const windowTitle = 'windownameremovelistener';
+      const windowOptions = getWindowOptions({
+        name: windowTitle
+      });
+
+      const addWindowListener = (event) => {
+        /* eslint-disable no-undef */
+        const script = (event, callback) => {
+          // We need to save the function, as we need to pass the same function object to removeListener
+          window.customListener = () => console.log(event);
+          var currentWin = ssf.Window.getCurrentWindow();
+          currentWin.addListener(event, window.customListener);
+          callback();
+        };
+        /* eslint-enable no-undef */
+        return executeAsyncJavascript(app.client, script, event);
+      };
+
+      const removeWindowListener = (event) => {
+        /* eslint-disable no-undef */
+        const script = (event, callback) => {
+          var currentWin = ssf.Window.getCurrentWindow();
+          currentWin.removeListener(event, window.customListener);
+          callback();
+        };
+        /* eslint-enable no-undef */
+        return executeAsyncJavascript(app.client, script, event);
+      };
+
+      const steps = [
+        ...setupWindowSteps(windowOptions),
+        () => addWindowListener('blur'),
+        () => removeWindowListener('blur'),
+        () => callWindowMethod('listenerCount', 'blur'),
+        (result) => assert.equal(result.value, 0)
+      ];
+
+      return chainPromises(steps);
+    });
+
+    it.only('Should remove all listeners from the window #ssf.Window.removeAllListeners #ssf.WindowCore.removeAllListeners', function() {
+      const windowTitle = 'windownameremovealllisteners';
+      const windowOptions = getWindowOptions({
+        name: windowTitle
+      });
+
+      const addWindowListener = (event, data) => {
+        /* eslint-disable no-undef */
+        const script = (event, data, callback) => {
+          // We need to save the function, as we need to pass the same function object to removeListener
+          var currentWin = ssf.Window.getCurrentWindow();
+          currentWin.addListener(event, () => console.log(event + data));
+          callback();
+        };
+        /* eslint-enable no-undef */
+        return executeAsyncJavascript(app.client, script, event, data);
+      };
+
+      const removeWindowListeners = (event) => {
+        /* eslint-disable no-undef */
+        const script = (event, callback) => {
+          var currentWin = ssf.Window.getCurrentWindow();
+          currentWin.removeAllListeners(event);
+          callback();
+        };
+        /* eslint-enable no-undef */
+        return executeAsyncJavascript(app.client, script, event);
+      };
+
+      const steps = [
+        ...setupWindowSteps(windowOptions),
+        () => addWindowListener('blur', 'one'),
+        () => addWindowListener('blur', 'two'),
+        () => removeWindowListeners('blur'),
+        () => callWindowMethod('listenerCount', 'blur'),
+        (result) => assert.equal(result.value, 0)
+      ];
+
+      return chainPromises(steps);
+    });
+
+    it.only('Should remove all listeners from all events when passed no event #ssf.Window.removeAllListeners #ssf.WindowCore.removeAllListeners', function() {
+      const windowTitle = 'windownameremovealllistenersallevents';
+      const windowOptions = getWindowOptions({
+        name: windowTitle
+      });
+
+      const addWindowListener = (event, data) => {
+        /* eslint-disable no-undef */
+        const script = (event, data, callback) => {
+          // We need to save the function, as we need to pass the same function object to removeListener
+          var currentWin = ssf.Window.getCurrentWindow();
+          currentWin.addListener(event, () => console.log(event + data));
+          callback();
+        };
+        /* eslint-enable no-undef */
+        return executeAsyncJavascript(app.client, script, event, data);
+      };
+
+      const removeWindowListeners = () => {
+        /* eslint-disable no-undef */
+        const script = (callback) => {
+          var currentWin = ssf.Window.getCurrentWindow();
+          currentWin.removeAllListeners();
+          callback();
+        };
+        /* eslint-enable no-undef */
+        return executeAsyncJavascript(app.client, script);
+      };
+
+      const steps = [
+        ...setupWindowSteps(windowOptions),
+        () => addWindowListener('blur', 'one'),
+        () => addWindowListener('blur', 'two'),
+        () => addWindowListener('focus', 'one'),
+        () => removeWindowListeners('blur'),
+        () => callWindowMethod('listenerCount', 'blur'),
+        (result) => assert.equal(result.value, 0),
+        () => callWindowMethod('listenerCount', 'focus'),
+        (result) => assert.equal(result.value, 0)
+      ];
+
+      return chainPromises(steps);
+    });
+
     it('Should set the bounds #ssf.Window.setBounds #ssf.WindowCore.setBounds', function() {
       const windowTitle = 'windownamesetbounds';
       const bounds = { x: 0, y: 0, width: 500, height: 500 };

--- a/packages/api-tests/test/window.core.spec.js
+++ b/packages/api-tests/test/window.core.spec.js
@@ -426,7 +426,7 @@ describe('WindowCore API', function(done) {
       return chainPromises(steps);
     });
 
-    it.only('Should remove a listener from the window #ssf.Window.removeListener #ssf.WindowCore.removeListener', function() {
+    it('Should remove a listener from the window #ssf.Window.removeListener #ssf.WindowCore.removeListener', function() {
       const windowTitle = 'windownameremovelistener';
       const windowOptions = getWindowOptions({
         name: windowTitle
@@ -467,7 +467,7 @@ describe('WindowCore API', function(done) {
       return chainPromises(steps);
     });
 
-    it.only('Should remove all listeners from the window #ssf.Window.removeAllListeners #ssf.WindowCore.removeAllListeners', function() {
+    it('Should remove all listeners from the window #ssf.Window.removeAllListeners #ssf.WindowCore.removeAllListeners', function() {
       const windowTitle = 'windownameremovealllisteners';
       const windowOptions = getWindowOptions({
         name: windowTitle
@@ -500,15 +500,18 @@ describe('WindowCore API', function(done) {
         ...setupWindowSteps(windowOptions),
         () => addWindowListener('blur', 'one'),
         () => addWindowListener('blur', 'two'),
+        () => addWindowListener('focus', 'one'),
         () => removeWindowListeners('blur'),
         () => callWindowMethod('listenerCount', 'blur'),
-        (result) => assert.equal(result.value, 0)
+        (result) => assert.equal(result.value, 0),
+        () => callWindowMethod('listenerCount', 'focus'),
+        (result) => assert.equal(result.value, 1)
       ];
 
       return chainPromises(steps);
     });
 
-    it.only('Should remove all listeners from all events when passed no event #ssf.Window.removeAllListeners #ssf.WindowCore.removeAllListeners', function() {
+    it('Should remove all listeners from all events when passed no event #ssf.Window.removeAllListeners #ssf.WindowCore.removeAllListeners', function() {
       const windowTitle = 'windownameremovealllistenersallevents';
       const windowOptions = getWindowOptions({
         name: windowTitle
@@ -542,7 +545,7 @@ describe('WindowCore API', function(done) {
         () => addWindowListener('blur', 'one'),
         () => addWindowListener('blur', 'two'),
         () => addWindowListener('focus', 'one'),
-        () => removeWindowListeners('blur'),
+        () => removeWindowListeners(),
         () => callWindowMethod('listenerCount', 'blur'),
         (result) => assert.equal(result.value, 0),
         () => callWindowMethod('listenerCount', 'focus'),


### PR DESCRIPTION
This adds event emitter methods (i.e. `on`, `once` etc.) to the window object. There are some methods of the `Node.EventEmitter` that could not be implemented (such as `prependListener` in OpenFin).

_Note:_ The Electron `BrowserWindow` object is an event emitter, but we couldn't use most of the methods it provided (such as `win.listeners(event)`) because the remote module adds listeners for multiple events to control the window from the main process. This would be inconsistent with OpenFin/Browser so the same implementation was used in Electron as in those APIs 