### PR TITLE
Fix electron getChildWindows tests failing

### DIFF
--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -266,7 +266,7 @@ class Window implements ssf.Window {
         child.id = String(win.id);
         children.push(child);
       });
-      return children;
+      resolve(children);
     });
   }
 


### PR DESCRIPTION
The promise for `getChildWindows` wasn't being resolved.