### PR TITLE
Fix issue with opening the child window in the messaging demo

### DIFF
--- a/packages/api-demo/src/messaging/messaging-api-demo.js
+++ b/packages/api-demo/src/messaging/messaging-api-demo.js
@@ -16,7 +16,7 @@ appReady.then(() => {
 
     const isChild = document.getElementById('child').checked;
 
-    const path = location.href.substring(0, location.href.lastIndexOf('/'))
+    const path = location.href.substring(0, location.href.lastIndexOf('/'));
 
     // eslint-disable-next-line no-new
     new ssf.Window({

--- a/packages/api-demo/src/messaging/messaging-api-demo.js
+++ b/packages/api-demo/src/messaging/messaging-api-demo.js
@@ -16,12 +16,14 @@ appReady.then(() => {
 
     const isChild = document.getElementById('child').checked;
 
+    const path = location.href.substring(0, location.href.lastIndexOf('/'))
+
     // eslint-disable-next-line no-new
     new ssf.Window({
       child: isChild,
       name: id,
       show: true,
-      url: `http://localhost:${location.port}/messaging-api-test-window.html`
+      url: `${path}/messaging-api-test-window.html`
     });
   };
 

--- a/packages/api-demo/src/messaging/messaging-api-test-window.html
+++ b/packages/api-demo/src/messaging/messaging-api-test-window.html
@@ -25,7 +25,7 @@
 
   <form class="form">
     <div class="form-group">
-      <label>Application Id</label>
+      <label>Window Id</label>
       <input type="text" class="form-control" placeholder="Id" id="uuid">
     </div>
     <div class="form-group">


### PR DESCRIPTION
The html file is now in a sub folder. The new code also doesn't assume
that the application is running on the localhost.
The label change makes it consistent with the parent window.