### PR TITLE
Fix electron event tests failing because of call stack size

### DIFF
--- a/packages/api-tests/test/window.spec.js
+++ b/packages/api-tests/test/window.spec.js
@@ -653,7 +653,8 @@ if (process.env.MOCHA_CONTAINER !== 'browser') {
         /* eslint-disable no-undef */
         const script = (event, callback) => {
           const currentWindow = ssf.Window.getCurrentWindow();
-          callback(currentWindow.addListener(event, () => { window.listenEventResult = true; }));
+          currentWindow.addListener(event, () => { window.listenEventResult = true; });
+          callback();
         };
         /* eslint-enable no-undef */
         return executeAsyncJavascript(app.client, script, event);


### PR DESCRIPTION
The listener tests were returning the result from `addListener` in the callback. With the change to the window events, the `addListener` method now returns the window object, which exceeds the maximum size for an object that can be sent with webdriver/spectron, so the tests fail.