### PR TITLE
Update electron test setup to use ssf-electron binary

### DIFF
--- a/packages/api-electron/main.js
+++ b/packages/api-electron/main.js
@@ -8,7 +8,7 @@ let win;
 
 function createWindow() {
   // the appJson location is passed to the ssf-electron bin script
-  const configLocation = process.env.TEST ? 'src/app.json' : process.argv[5];
+  const configLocation = process.argv[5];
   const appJsonPath = process.cwd() + '/' + configLocation;
   const appJson = JSON.parse(fs.readFileSync(appJsonPath, 'utf8'));
 

--- a/packages/api-tests/test/electron-test-setup.js
+++ b/packages/api-tests/test/electron-test-setup.js
@@ -1,14 +1,11 @@
 const Application = require('spectron').Application;
 const path = require('path');
-const electronPath = path.join(__dirname, '..', 'node_modules', '.bin', 'electron');
+const electronPath = path.join(__dirname, '..', 'node_modules', '.bin', 'ssf-electron');
 
-module.exports = () => {
+module.exports = (timeout) => {
   const extension = process.platform === 'win32' ? '.cmd' : '';
   return new Application({
     path: electronPath + extension,
-    args: [path.join('node_modules', 'containerjs-api-electron', 'main.js')],
-    env: {
-      TEST: true
-    }
+    args: ['app.json']
   });
 };


### PR DESCRIPTION
As the OpenFin tests now use the `ssf-openfin` binary, it seems like a good idea for the electron tests to use the `ssf-electron` binary.