### PR TITLE
Fix for console error showing in electron and browser

### DIFF
--- a/packages/api-openfin/src/main-process.ts
+++ b/packages/api-openfin/src/main-process.ts
@@ -114,6 +114,13 @@ const mainWindowCode = () => {
 };
 
 const createMainProcess = (done) => {
+  // Populate the current window variable
+  ssf.Window.getCurrentWindow();
+
+  fin.desktop.InterApplicationBus.subscribe('*', 'ssf-close-all', () => {
+    fin.desktop.Window.getCurrent().close(true);
+  });
+
   // Create the main window, if the window already exists, the success callback isn't ran
   // and the already open window is returned
   const app = new fin.desktop.Application({

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -524,13 +524,4 @@ class Window implements ssf.Window {
   }
 }
 
-if ('fin' in window) {
-  // Populate the current window variable
-  Window.getCurrentWindow();
-
-  fin.desktop.InterApplicationBus.subscribe('*', 'ssf-close-all', () => {
-    fin.desktop.Window.getCurrent().close(true);
-  });
-}
-
 export default Window;

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -524,11 +524,13 @@ class Window implements ssf.Window {
   }
 }
 
-// Populate the current window variable
-Window.getCurrentWindow();
+if ('fin' in window) {
+  // Populate the current window variable
+  Window.getCurrentWindow();
 
-fin.desktop.InterApplicationBus.subscribe('*', 'ssf-close-all', () => {
-  fin.desktop.Window.getCurrent().close(true);
-});
+  fin.desktop.InterApplicationBus.subscribe('*', 'ssf-close-all', () => {
+    fin.desktop.Window.getCurrent().close(true);
+  });
+}
 
 export default Window;


### PR DESCRIPTION
I'm not sure if there is a better way to do this, would be nice if we could wrap all of the OpenFin API with `if ('fin' in window)` but not sure if roll-up supports this sort of thing. I think it makes sense when developing that the code written in `api-openfin` would only ever be executed in OpenFin.

Closes #233 