### PR TITLE
Refector typescript interface into separate files

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -10,7 +10,7 @@
     <div class="collapse navbar-collapse" id="navbarToggler">
       <ul class="navbar-nav ml-auto mt-2 mt-md-0">
         <li {% if page.sectionid == 'docs' %} class="nav-item active" {% else %} class="nav-item" {% endif %}>
-          <a class="nav-link" href="/ContainerJS/Docs">Documentation</a>
+          <a class="nav-link" href="/ContainerJS/Docs.html">Documentation</a>
         </li>
       </ul>
       <a class="nav-link p-1" href="https://github.com/symphonyoss/ContainerJS">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,5 +1,5 @@
 (function() {
-  if (window.location.pathname.split('/').filter(x => x).pop().toLowerCase() === 'docs') {
+  if (window.location.pathname.split('/').filter(x => x).pop().toLowerCase() === 'docs.html') {
     const classMenu = document.getElementById('class-menu');
     const interfaceMenu = document.getElementById('interface-menu');
     const classSections = document.getElementsByClassName('docs-title');

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -57,8 +57,7 @@ p {
   margin-top: 12px;
 }
 
-.code, pre {
-  width: 100%;
+.code, pre, .code-small {
   font-family: monospace;
   white-space: pre;
   background-color: #eee;
@@ -66,6 +65,10 @@ p {
   padding: 10px 10px;
   margin: 5px 0;
   font-weight: 500;
+}
+
+.code, pre {
+  width: 100%;
 }
 
 .method {

--- a/packages/api-browser/tsconfig.json
+++ b/packages/api-browser/tsconfig.json
@@ -15,6 +15,6 @@
     },
     "include": [
         "./index.ts",
-        "node_modules/containerjs-api-specification/interface.ts"
+        "node_modules/containerjs-api-specification/interface/*.ts"
     ]
 }

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -15,7 +15,7 @@ class Window implements ssf.Window {
   id: string;
   eventListeners: Map<string, ((...args: any[]) => void)[]> = new Map();
 
-  constructor(options: ssf.WindowOptions, callback, errorCallback) {
+  constructor(options?: ssf.WindowOptions, callback?: (window: Window) => void, errorCallback?: () => void) {
     MessageService.subscribe('*', 'ssf-window-message', (...args) => {
       const event = 'message';
       this.innerWindow.emit(event, ...args);

--- a/packages/api-electron/tsconfig.json
+++ b/packages/api-electron/tsconfig.json
@@ -15,6 +15,6 @@
     },
     "include": [
         "./preload.ts",
-        "node_modules/containerjs-api-specification/interface.ts"
+        "node_modules/containerjs-api-specification/interface/*.ts"
     ]
 }

--- a/packages/api-openfin/tsconfig.json
+++ b/packages/api-openfin/tsconfig.json
@@ -15,6 +15,6 @@
     },
     "include": [
         "./index.ts",
-        "node_modules/containerjs-api-specification/interface.ts"
+        "node_modules/containerjs-api-specification/interface/*.ts"
     ]
 }

--- a/packages/api-specification/interface/app.ts
+++ b/packages/api-specification/interface/app.ts
@@ -1,0 +1,8 @@
+declare namespace ssf {
+  class App {
+    /**
+     * A promise that resolves when the API has finished bootstrapping.
+     */
+    static ready(): Promise<any>;
+  }
+}

--- a/packages/api-specification/interface/event-emitter.ts
+++ b/packages/api-specification/interface/event-emitter.ts
@@ -1,0 +1,57 @@
+declare namespace ssf {
+  /**
+   * Exposes methods that allow subscribing to particular events
+   */
+  abstract class EventEmitter {
+    /**
+     * Adds a listener that runs when the specified event occurs. Alias for <span class="code-small">on()</span>.
+     * @param event The event to listen for.
+     * @param listener The function to run when the event occurs.
+     */
+    addListener(event: string, listener: Function): EventEmitter;
+
+    /**
+     * Adds a listener that runs when the specified event occurs. Alias for <span class="code-small">addListener()</span>.
+     * @param event The event to listen for.
+     * @param listener The function to run when the event occurs.
+     */
+    on(event: string, listener: Function): EventEmitter;
+
+    /**
+     * Adds a listener that runs once when the specified event occurs, then is removed.
+     * @param event The event to listen for.
+     * @param listener The function to run once when the event occurs.
+     */
+    once(event: string, listener: Function): EventEmitter;
+
+    /**
+     * Get all event names with active listeners.
+     */
+    eventNames(): Array<string|symbol>;
+
+    /**
+     * Get the number of listeners currently listening for an event.
+     * @param event The event to get the number of listeners for.
+     */
+    listenerCount(event: string): number;
+
+    /**
+     * Get all listeners for an event.
+     * @param event The event to get the listeners for.
+     */
+    listeners(event: string): Array<Function>;
+
+    /**
+     * Remove a listener from an event.
+     * @param event The event to remove the listener from.
+     * @param listener The listener to remove. Must be the same object that was passed to <span class="code-small">addListener()</span>
+     */
+    removeListener(event: string, listener: Function): EventEmitter;
+
+    /**
+     * Removes all listeners from a given event, or all events if no event is passed.
+     * @param event The event to remove the listeners from.
+     */
+    removeAllListeners(event?: string): EventEmitter;
+  }
+}

--- a/packages/api-specification/interface/message-service.ts
+++ b/packages/api-specification/interface/message-service.ts
@@ -1,0 +1,27 @@
+declare namespace ssf {
+  class MessageService {
+    /**
+     * Send a message to a specific window
+     * @param windowId - The id of the window to send the message to.
+     * @param topic - The topic of the message.
+     * @param message - The message to send.
+     */
+    static send(windowId: string, topic :string, message: string|object): void;
+
+    /**
+     * Subscribe to message from a window/topic
+     * @param windowId - The id of the window to listen to messages fron. Can be a wildcard '*' to listen to all windows.
+     * @param topic - The topic to listen for.
+     * @param listener - The function to run when a message is received. The message is passed as a parameter to the function.
+     */
+    static subscribe(windowId: string, topic :string, listener: Function): void;
+
+    /**
+     * Unsubscribe from a window/topic
+     * @param windowId - The id of the window that the listener was subscribed to or the wildcard '*'.
+     * @param topic - The topic that was being listened to.
+     * @param listener - The function that was passed to subscribe. _Note:_ this must be the same function object.
+     */
+    static unsubscribe(windowId: string, topic :string, listener: Function): void;
+  }
+}

--- a/packages/api-specification/interface/notification.ts
+++ b/packages/api-specification/interface/notification.ts
@@ -1,0 +1,20 @@
+declare namespace ssf {
+  class NotificationOptions {
+    /**
+     * The text to display underneath the title text.
+     */
+    body?: string;
+  }
+  type NotificationPermission = "default" | "denied" | "granted";
+
+  class Notification {
+    /**
+     * Create a notification
+     * @param title - The title text of the notification.
+     * @param options - The notification options.
+     */
+    constructor(title: string, options: NotificationOptions);
+
+    static requestPermission(): Promise<NotificationPermission>;
+  }
+}

--- a/packages/api-specification/interface/openfin-extension.ts
+++ b/packages/api-specification/interface/openfin-extension.ts
@@ -1,0 +1,13 @@
+/**
+ * @ignore
+ */
+declare namespace fin {
+  interface OpenFinWindow {
+    uuid: string;
+    executeJavaScript(code: string, callback?: Function, errorCallback?: Function): void;
+  }
+
+  interface WindowOptions {
+    preload?: string;
+  }
+}

--- a/packages/api-specification/interface/rectangle.ts
+++ b/packages/api-specification/interface/rectangle.ts
@@ -1,0 +1,8 @@
+declare namespace ssf {
+  export interface Rectangle {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+}

--- a/packages/api-specification/interface/screen-snippet.ts
+++ b/packages/api-specification/interface/screen-snippet.ts
@@ -1,0 +1,8 @@
+declare namespace ssf {
+  class ScreenSnippet {
+    /**
+     * Captures the current visible screen. Returns the image as a base64 encoded png string.
+     */
+    capture(): Promise<string>;
+  }
+}

--- a/packages/api-specification/interface/window-extension.ts
+++ b/packages/api-specification/interface/window-extension.ts
@@ -1,8 +1,0 @@
-declare interface Window {
-  /**
-   * Create a notification
-   * @param title - The title text of the notification.
-   * @param options - The notification options.
-   */
-  Notification(title: string, options: ssf.NotificationOptions): void;
-}

--- a/packages/api-specification/interface/window-extension.ts
+++ b/packages/api-specification/interface/window-extension.ts
@@ -1,0 +1,8 @@
+declare interface Window {
+  /**
+   * Create a notification
+   * @param title - The title text of the notification.
+   * @param options - The notification options.
+   */
+  Notification(title: string, options: ssf.NotificationOptions): void;
+}

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -128,7 +128,7 @@ declare namespace ssf {
     /**
      * Get all event names with active listeners.
      */
-    eventNames(): (string|symbol)[];
+    eventNames(): Array<string|symbol>;
 
     /**
      * Get the number of listeners currently listening for an event.
@@ -140,7 +140,7 @@ declare namespace ssf {
      * Get all listeners for an event.
      * @param event The event to get the listeners for.
      */
-    listeners(event: string): Function[];
+    listeners(event: string): Array<Function>;
 
     /**
      * Remove a listener from an event.

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -4,28 +4,11 @@
 // Needed to access the browsers window object
 type BrowserWindow = Window;
 
-/**
- * @ignore
- */
-declare namespace fin {
-  interface OpenFinWindow {
-    uuid: string;
-    executeJavaScript(code: string, callback?: Function, errorCallback?: Function): void;
-  }
-
-  interface WindowOptions {
-    preload?: string;
-  }
-}
-
 declare namespace ssf {
-  interface Rectangle {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  }
 
+  /**
+   * Options that can be passed to the window constructor
+   */
   interface WindowOptions {
     /**
      * Default window title.
@@ -117,7 +100,10 @@ declare namespace ssf {
     transparent?: boolean;
   }
 
-  class EventEmitter {
+  /**
+   * Exposes methods that allow subscribing to particular events
+   */
+  abstract class EventEmitter {
     /**
      * Adds a listener that runs when the specified event occurs. Alias for <span class="code">on()</span>.
      * @param event The event to listen for.
@@ -126,7 +112,7 @@ declare namespace ssf {
     addListener(event: string, listener: Function): EventEmitter;
 
     /**
-     * Adds a listener that runs when the specified event occurs. Alias for <span class="code">addListener()</span>.
+     * Adds a listener that runs when the specified event occurs. Alias for <span class="code-small">addListener()</span>.
      * @param event The event to listen for.
      * @param listener The function to run when the event occurs.
      */
@@ -159,7 +145,7 @@ declare namespace ssf {
     /**
      * Remove a listener from an event.
      * @param event The event to remove the listener from.
-     * @param listener The listener to remove. Must be the same object that was passed to <span class="code">addListener()</span>
+     * @param listener The listener to remove. Must be the same object that was passed to <span class="code-small">addListener()</span>
      */
     removeListener(event: string, listener: Function): EventEmitter;
 
@@ -202,7 +188,7 @@ declare namespace ssf {
     show: 'show';
   }
 
-  class WindowCore extends EventEmitter {
+  export abstract class WindowCore extends EventEmitter {
     /**
      * The id that uniquely identifies the window
      */
@@ -214,13 +200,12 @@ declare namespace ssf {
     innerWindow: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow;
 
     /**
-
      * Create a new window.
      * @param opts A window options object
      * @param callback A callback that is called if the window creation succeeds
      * @param errorCallback A callback that is called if window creation fails
      */
-    constructor(opts?: WindowOptions, callback?: Function, errorCallback?: Function);
+    constructor(opts?: WindowOptions, callback?: (window: Window) => void, errorCallback?: () => void);
 
     /**
      * Removes focus from the window.
@@ -233,7 +218,7 @@ declare namespace ssf {
      */
     close(): Promise<void>;
 
-     /**
+      /**
      * Focuses the window.
      * @returns A promise which resolves to nothing when the function has completed.
      */
@@ -243,7 +228,7 @@ declare namespace ssf {
      * Returns the bounds of the window.
      * @returns A promise that resolves to an object specifying the bounds of the window.
      */
-    getBounds(): Promise<Rectangle>;
+    getBounds(): Promise<ssf.Rectangle>;
 
     /**
      * Get the child windows of the window.
@@ -317,7 +302,7 @@ declare namespace ssf {
      * @param bounds - Sets the bounds of the window.
      * @returns A promise that resolves to nothing when the option is set.
      */
-    setBounds(bounds: Rectangle): Promise<void>;
+    setBounds(bounds: ssf.Rectangle): Promise<void>;
 
     /**
      * Sets the windows position. Only works on windows created via the ContainerJS API in the browser.
@@ -347,7 +332,7 @@ declare namespace ssf {
      * @param errorCallback - Function that is called when the window could not be created.
      * @returns The window.
      */
-    static getCurrentWindow(callback: Function, errorCallback: Function): Window;
+    static getCurrentWindow(callback?: () => void, errorCallback?: () => void): Window;
   }
 
   /**
@@ -360,8 +345,7 @@ declare namespace ssf {
     * const win = new Window({url: 'http://localhost/index.html'});
     * </pre>
     */
-  class Window extends WindowCore {
-
+  export class Window extends WindowCore {
     /**
      * Flashes the window's frame and taskbar icon.
      * @param flag - Flag to start or stop the window flashing.
@@ -435,7 +419,7 @@ declare namespace ssf {
      * @param bounds - Sets the bounds of the window.
      * @returns A promise that resolves to nothing when the option is set.
      */
-    setBounds(bounds: Rectangle): Promise<void>;
+    setBounds(bounds: ssf.Rectangle): Promise<void>;
 
     /**
      * Sets the window icon.
@@ -527,73 +511,5 @@ declare namespace ssf {
      * @returns A promise that resolves to nothing when the window has unmaximized.
      */
     unmaximize(): Promise<void>;
-
-    /**
-     * Gets the current window object.
-     * @param callback - Function that is called when the window is created successfully.
-     * @param errorCallback - Function that is called when the window could not be created.
-     * @returns The window.
-     */
-    static getCurrentWindow(callback?: Function, errorCallback?: Function): Window;
   }
-
-  class MessageService {
-    /**
-     * Send a message to a specific window
-     * @param windowId - The id of the window to send the message to.
-     * @param topic - The topic of the message.
-     * @param message - The message to send.
-     */
-    static send(windowId: string, topic :string, message: string|object): void;
-
-    /**
-     * Subscribe to message from a window/topic
-     * @param windowId - The id of the window to listen to messages fron. Can be a wildcard '*' to listen to all windows.
-     * @param topic - The topic to listen for.
-     * @param listener - The function to run when a message is received. The message is passed as a parameter to the function.
-     */
-    static subscribe(windowId: string, topic :string, listener: Function): void;
-
-    /**
-     * Unsubscribe from a window/topic
-     * @param windowId - The id of the window that the listener was subscribed to or the wildcard '*'.
-     * @param topic - The topic that was being listened to.
-     * @param listener - The function that was passed to subscribe. _Note:_ this must be the same function object.
-     */
-    static unsubscribe(windowId: string, topic :string, listener: Function): void;
-  }
-
-  class ScreenSnippet {
-    /**
-     * Captures the current visible screen. Returns the image as a base64 encoded png string.
-     */
-    capture(): Promise<string>;
-  }
-
-  class App {
-    /**
-     * A promise that resolves when the API has finished bootstrapping.
-     */
-    static ready(): Promise<any>;
-  }
-
-  class NotificationOptions {
-    /**
-     * The text to display underneath the title text.
-     */
-    body?: string;
-  }
-  type NotificationPermission = "default" | "denied" | "granted";
-
-  class Notification {
-    /**
-     * Create a notification
-     * @param title - The title text of the notification.
-     * @param options - The notification options.
-     */
-    constructor(title: string, options: NotificationOptions);
-
-    static requestPermission(): Promise<NotificationPermission>;
-  }
-
 }

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -100,62 +100,6 @@ declare namespace ssf {
     transparent?: boolean;
   }
 
-  /**
-   * Exposes methods that allow subscribing to particular events
-   */
-  abstract class EventEmitter {
-    /**
-     * Adds a listener that runs when the specified event occurs. Alias for <span class="code-small">on()</span>.
-     * @param event The event to listen for.
-     * @param listener The function to run when the event occurs.
-     */
-    addListener(event: string, listener: Function): EventEmitter;
-
-    /**
-     * Adds a listener that runs when the specified event occurs. Alias for <span class="code-small">addListener()</span>.
-     * @param event The event to listen for.
-     * @param listener The function to run when the event occurs.
-     */
-    on(event: string, listener: Function): EventEmitter;
-
-    /**
-     * Adds a listener that runs once when the specified event occurs, then is removed.
-     * @param event The event to listen for.
-     * @param listener The function to run once when the event occurs.
-     */
-    once(event: string, listener: Function): EventEmitter;
-
-    /**
-     * Get all event names with active listeners.
-     */
-    eventNames(): Array<string|symbol>;
-
-    /**
-     * Get the number of listeners currently listening for an event.
-     * @param event The event to get the number of listeners for.
-     */
-    listenerCount(event: string): number;
-
-    /**
-     * Get all listeners for an event.
-     * @param event The event to get the listeners for.
-     */
-    listeners(event: string): Array<Function>;
-
-    /**
-     * Remove a listener from an event.
-     * @param event The event to remove the listener from.
-     * @param listener The listener to remove. Must be the same object that was passed to <span class="code-small">addListener()</span>
-     */
-    removeListener(event: string, listener: Function): EventEmitter;
-
-    /**
-     * Removes all listeners from a given event, or all events if no event is passed.
-     * @param event The event to remove the listeners from.
-     */
-    removeAllListeners(event?: string): EventEmitter;
-  }
-
   interface WindowEvent {
     /** Fires when the window has been blurred */
     blur: 'blur';
@@ -188,7 +132,7 @@ declare namespace ssf {
     show: 'show';
   }
 
-  export abstract class WindowCore extends EventEmitter {
+  export abstract class WindowCore extends ssf.EventEmitter {
     /**
      * The id that uniquely identifies the window
      */

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -105,7 +105,7 @@ declare namespace ssf {
    */
   abstract class EventEmitter {
     /**
-     * Adds a listener that runs when the specified event occurs. Alias for <span class="code">on()</span>.
+     * Adds a listener that runs when the specified event occurs. Alias for <span class="code-small">on()</span>.
      * @param event The event to listen for.
      * @param listener The function to run when the event occurs.
      */

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "typedoc2html": "node transform-type-info.js --testfile test-report.json --outfile ../../docs/Docs.html",
-    "typedoc": "typedoc --mode file --json type-info.json interface.ts",
+    "typedoc": "typedoc --mode modules --module system --json type-info.json interface/index.ts",
+    "combine": "tsc --out interface-test.ts",
     "docs": "npm run typedoc && npm run typedoc2html"
   },
   "author": "",

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "typedoc2html": "node transform-type-info.js --testfile test-report.json --outfile ../../docs/Docs.html",
-    "typedoc": "typedoc --mode modules --module system --json type-info.json interface/index.ts",
-    "combine": "tsc --out interface-test.ts",
+    "typedoc": "typedoc --mode file --json type-info.json interface",
     "docs": "npm run typedoc && npm run typedoc2html"
   },
   "author": "",

--- a/packages/api-specification/transform-type-info.js
+++ b/packages/api-specification/transform-type-info.js
@@ -98,6 +98,9 @@ const formatType = (type) => {
         (type.typeArguments !== undefined ? '&lt;' + type.typeArguments.map(formatType).join(', ') + '&gt;' : '');
     case 'union':
       return type.types.map(formatType).join(' | ');
+    case 'reflection':
+      const parameters = type.declaration.signatures[0].parameters || [];
+      return '(' + parameters.map((param) => param.name + ': ' + formatType(param.type)).join(',') + ') => ' + formatType(type.declaration.signatures[0].type);
   }
   return 'UNKNOWN';
 };

--- a/packages/api-symphony-compatibility/tsconfig.json
+++ b/packages/api-symphony-compatibility/tsconfig.json
@@ -15,6 +15,6 @@
     },
     "include": [
         "./index.ts",
-        "node_modules/containerjs-api-specification/interface.ts"
+        "node_modules/containerjs-api-specification/interface/*.ts"
     ]
 }


### PR DESCRIPTION
Split the interface up into separate files to make it easier to work on different parts of the API. Also updated some of the types that were displaying as 'UNKNOWN' in the documentation. Example:
[`eventNames`](https://symphonyoss.github.io/ContainerJS/Docs#EventEmitter) to
![image](https://user-images.githubusercontent.com/9324259/27952078-f8ee0334-62fe-11e7-8a5e-f0a5703873af.png)
