### PR TITLE
Update readme for published packages

### DIFF
--- a/packages/api-browser/README.md
+++ b/packages/api-browser/README.md
@@ -7,7 +7,7 @@ This project provides an implementation of ContainerJS which follows the Symphon
 Add this package to your project:
 
 ```
-npm install ssf-desktop-api-browser --save
+npm install containerjs-api-browser --save
 ```
 
 You need to include this code into the project by loading the JavaScript file directly.

--- a/packages/api-electron/README.md
+++ b/packages/api-electron/README.md
@@ -1,13 +1,14 @@
 # ContainerJS API for Electron
 
-This project provides an implementation of ContainerJS which follows the Symphony Desktop Wrapper API Specification for Electron
+This project provides an implementation of ContainerJS which follows the Symphony Desktop Wrapper API Specification for Electron.
+For more information, see [The ContainerJS website](https://symphonyoss.github.io/ContainerJS/)
 
 ## Usage
 
 Add this package to your electron project:
 
 ```
-npm install ssf-desktop-api-electron --save
+npm install containerjs-api-electron --save
 ```
 
 You need to integrate this code into both your main process and your renderer processes via a preload script.
@@ -17,7 +18,7 @@ You need to integrate this code into both your main process and your renderer pr
 This module needs to register IPC handlers once the app `ready` event has fired. This can be done as follows:
 
 ```
-const ssfElectron = require('ssf-desktop-api-electron');
+const ssfElectron = require('containerjs-api-electron');
 
 function createWindow () {
   ssfElectron(url);
@@ -31,4 +32,18 @@ where `url` is the URL to load in the hidden window.
 
 ### Renderer process integration
 
-The call to ssfElectron will create a browser window that will not be shown, and will load the URL passed into `ssfElectron()`. From here, use `new ssf.Window()` to create windows.
+The call to ssfElectron will create a browser window and will load the URL passed in the `app.json` file. From here, use `new ssf.Window()` to create windows.
+
+### Running the app
+
+Use the `ssf-electron` binary to run the application. This can be installed globally by doing:
+
+```
+npm install --global containerjs-api-electron
+```
+
+To run the application, do:
+
+```
+ssf-electron ./path/to/app.json
+```

--- a/packages/api-openfin/README.md
+++ b/packages/api-openfin/README.md
@@ -1,13 +1,27 @@
 # ContainerJS API for OpenFin
 
 This project provides an implementation of ContainerJS which follows the Symphony Desktop Wrapper API Specification for OpenFin
+For more information, see [The ContainerJS website](https://symphonyoss.github.io/ContainerJS/)
 
 ## Usage
 
 Add this package to your OpenFin project:
 
 ```
-npm install ssf-desktop-api-openfin --save
+npm install containerjs-api-openfin --save
 ```
 
-You need to include this code into the project by loading the JavaScript file directly (as OpenFin does not support preloading).
+### Running the app
+
+Use the `ssf-openfin` binary to run the application. This can be installed globally by doing:
+
+```
+npm install --global containerjs-api-electron
+```
+
+To run the application, do:
+
+```
+ssf-openfin --config ./path/to/app.json
+```
+

--- a/packages/api-symphony-compatibility/README.md
+++ b/packages/api-symphony-compatibility/README.md
@@ -1,0 +1,17 @@
+# ContainerJS Compatibility API
+
+This project provides an mapping from the Symphony API that can be found [here](https://symphonyoss.atlassian.net/wiki/display/WGDWAPI/) to ContainerJS.
+For more information, see [The ContainerJS website](https://symphonyoss.github.io/ContainerJS/)
+
+## Usage
+
+Add this package to your project:
+
+```
+npm install containerjs-api-compatibility --save
+```
+
+The compatibility file must be included directly like so:
+```
+<script src="/scripts/containerjs-compatibility-api"></script>
+```

--- a/packages/api-symphony-compatibility/demo/index.html
+++ b/packages/api-symphony-compatibility/demo/index.html
@@ -32,7 +32,7 @@
 </div>
 
 <script src="/scripts/containerjs-api-bundle"></script>
-<script src="/scripts/containerjs-compatibility-api"></script>
+<script src="/scripts/containerjs-api-compatibility"></script>
 <script>
   const xPos = document.getElementById('xPos');
   const yPos = document.getElementById('yPos');

--- a/packages/api-symphony-compatibility/package.json
+++ b/packages/api-symphony-compatibility/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "containerjs-compatibility-api",
+  "name": "containerjs-api-compatibility",
   "version": "0.0.1",
   "description": "",
   "main": "index.js",

--- a/packages/api-symphony-compatibility/rollup.config.js
+++ b/packages/api-symphony-compatibility/rollup.config.js
@@ -2,5 +2,5 @@ export default {
   entry: 'build/es/index.js',
   format: 'umd',
   moduleName: 'ssf',
-  dest: 'build/dist/containerjs-compatibility-api.js'
+  dest: 'build/dist/containerjs-api-compatibility.js'
 };


### PR DESCRIPTION
Updated the READMEs for all published packages. Also changed `containerjs-compatibility-api` to `containerjs-api-compatibility` to be consistent with the other package names.