### PR TITLE
Update package.json files with correct information

### DIFF
--- a/packages/api-browser/package.json
+++ b/packages/api-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "containerjs-api-browser",
   "version": "0.0.1",
-  "description": "",
+  "description": "The ContainerJS browser API",
   "main": "build/lib/index.js",
   "module": "build/es/index.js",
   "jsnext:main": "build/es/index.js",
@@ -13,6 +13,16 @@
     "build:cjs": "rimraf build/lib && tsc -p tsconfig.json -m CommonJS --outdir ./build/lib",
     "build:umd": "rimraf build/dist && npm run build:es && rollup -c"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/symphonyoss/ContainerJS.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/symphonyoss/ContainerJS/issues"
+  },
+  "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/api-bundle/package.json
+++ b/packages/api-bundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "containerjs-api-bundle",
   "version": "0.0.2",
-  "description": "A bundle of containerJS APIs",
+  "description": "A bundle of ContainerJS APIs",
   "main": "build/containerjs-bundle.js",
   "scripts": {
     "build": "rollup -c",
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/symphonyoss/ContainerJS/issues"
   },
-  "homepage": "https://github.com/symphonyoss/ContainerJS#readme",
+  "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
     "containerjs-api-openfin": "0.0.2",
     "containerjs-api-browser": "0.0.1"

--- a/packages/api-demo/package.json
+++ b/packages/api-demo/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "A bundle of containerJS APIs",
   "main": "src/index.js",
+  "private": true,
   "scripts": {
     "serve:no-browser": "npm run serve -- --no-browser",
     "serve": "live-server --mount=/:src --mount=/scripts/containerjs-api-bundle:node_modules/containerjs-api-bundle/build/containerjs-bundle.js --mount=/notifications/notification.html:node_modules/containerjs-api-bundle/build/notification.html",

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "containerjs-api-electron",
   "version": "0.0.2",
-  "description": "",
+  "description": "The ContainerJS Electron API",
   "main": "index.js",
   "module": "build/es/preload.js",
   "jsnext:main": "build/es/preload.js",
@@ -12,8 +12,16 @@
     "build:es": "rimraf build/es && tsc",
     "build:umd": "rimraf build/dist && npm run build:es && rollup -c"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/symphonyoss/ContainerJS.git"
+  },
   "author": "",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/symphonyoss/ContainerJS/issues"
+  },
+  "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
     "@types/electron": "1.4.37",
     "@types/electron-notify": "^0.1.3",

--- a/packages/api-openfin/package.json
+++ b/packages/api-openfin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "containerjs-api-openfin",
   "version": "0.0.2",
-  "description": "",
+  "description": "The ContainerJS OpenFin API",
   "main": "build/lib/index.js",
   "module": "build/es/index.js",
   "jsnext:main": "build/es/index.js",
@@ -13,8 +13,16 @@
     "build:cjs": "rimraf build/lib && tsc -p tsconfig.json -m CommonJS --outdir ./build/lib && copyfiles -f src/notification.html ./build/lib",
     "build:umd": "rimraf build/dist && npm run build:es && rollup -c && copyfiles -f src/notification.html ./build/dist"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/symphonyoss/ContainerJS.git"
+  },
   "author": "",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/symphonyoss/ContainerJS/issues"
+  },
+  "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "devDependencies": {
     "containerjs-api-specification": "0.0.2",
     "copyfiles": "^1.2.0",

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -1,15 +1,23 @@
 {
   "name": "containerjs-api-specification",
   "version": "0.0.2",
-  "description": "",
+  "description": "The interface for the ContainerJS API",
   "main": "index.js",
   "scripts": {
     "typedoc2html": "node transform-type-info.js --testfile test-report.json --outfile ../../docs/Docs.html",
     "typedoc": "typedoc --mode file --json type-info.json interface",
     "docs": "npm run typedoc && npm run typedoc2html"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/symphonyoss/ContainerJS.git"
+  },
   "author": "",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/symphonyoss/ContainerJS/issues"
+  },
+  "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
     "@types/electron": "1.4.37",
     "@types/openfin": "^17.0.2",

--- a/packages/api-symphony-compatibility/package.json
+++ b/packages/api-symphony-compatibility/package.json
@@ -1,10 +1,8 @@
 {
   "name": "containerjs-api-compatibility",
   "version": "0.0.1",
-  "description": "",
+  "description": "A compatibility layer between symphony electron and ContainerJS",
   "main": "index.js",
-  "author": "",
-  "license": "Apache-2.0",
   "scripts": {
     "clean": "rimraf build",
     "build": "npm run clean && npm run build:cjs && npm run build:es && rollup -c && copyfiles -f src/notification.html ./build/dist",
@@ -19,6 +17,16 @@
     "openfin": "npm-run-all --parallel launch:openfin serve:no-browser",
     "browser": "npm run serve"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/symphonyoss/ContainerJS.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/symphonyoss/ContainerJS/issues"
+  },
+  "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
     "containerjs-api-bundle": "0.0.2",
     "containerjs-api-electron": "0.0.2",

--- a/packages/api-tests/package.json
+++ b/packages/api-tests/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "license": "Apache-2.0",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "test:ui": "npm run test:electron && npm run test:browser && npm run test:openfin",
     "test:electron": "rimraf src && copyfiles -f \"demo/**\" src && cross-env MOCHA_CONTAINER=electron mocha test/*.js",


### PR DESCRIPTION
Get `package.json` files ready for release. Also makes `api-demo` and `api-tests` private (i.e. they are not published with lerna).