### PR TITLE
Add static window wrap method

### DIFF
--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -17,7 +17,7 @@ class Window implements ssf.WindowCore {
   eventListeners: Map<string, ((...args: any[]) => void)[]> = new Map();
   id: string;
 
-  constructor(options, callback?, errorCallback?) {
+  constructor(options?, callback?, errorCallback?) {
     this.children = [];
 
     this.eventListeners = new Map();
@@ -83,9 +83,7 @@ class Window implements ssf.WindowCore {
     return new Promise<Window>(resolve => {
       let newWin = null;
       if (window.opener) {
-        newWin = new Window(null);
-        newWin.innerWindow = window.opener;
-        newWin.id = window.opener.name;
+        newWin = Window.wrap(window.opener);
       }
 
       resolve(newWin);
@@ -241,6 +239,13 @@ class Window implements ssf.WindowCore {
 
     currentWindow = new Window(null, callback, errorCallback);
     return currentWindow;
+  }
+
+  static wrap(win: BrowserWindow) {
+    const wrappedWindow = new Window();
+    wrappedWindow.innerWindow = win;
+    wrappedWindow.id = String(win.name);
+    return wrappedWindow;
   }
 }
 

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -341,6 +341,13 @@ class Window implements ssf.Window {
     currentWindow = new Window(null, callback, errorCallback);
     return currentWindow;
   }
+
+  static wrap(win: Electron.BrowserWindow) {
+    const wrappedWindow = new Window();
+    wrappedWindow.innerWindow = win;
+    wrappedWindow.id = String(win.id);
+    return wrappedWindow;
+  }
 }
 
 export default Window;

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -133,7 +133,7 @@ class Window implements ssf.Window {
   innerWindow: fin.OpenFinWindow;
   id: string;
 
-  constructor(options: ssf.WindowOptions, callback?: any, errorCallback?: any) {
+  constructor(options?: ssf.WindowOptions, callback?: any, errorCallback?: any) {
     MessageService.subscribe('*', 'ssf-window-message', (...args) => {
       const event = 'message';
       if (this.eventListeners.has(event)) {
@@ -244,9 +244,7 @@ class Window implements ssf.Window {
         names.forEach((name) => {
           const app = fin.desktop.Application.wrap(name);
           const win = app.getWindow();
-          const childWin = new Window(undefined);
-          childWin.innerWindow = win;
-          childWin.id = win.uuid + ':' + win.name;
+          const childWin = Window.wrap(win);
           children.push(childWin);
         });
         resolve(children);
@@ -284,12 +282,9 @@ class Window implements ssf.Window {
           resolve(null);
           return;
         }
-
         const app = fin.desktop.Application.wrap(name);
         const win = app.getWindow();
-        const parentWin = new Window(undefined);
-        parentWin.innerWindow = win;
-        parentWin.id = win.uuid + ':' + win.name;
+        const parentWin = Window.wrap(win);
         resolve(parentWin);
       };
 
@@ -521,6 +516,13 @@ class Window implements ssf.Window {
 
     currentWindow = new Window(null, callback, errorCallback);
     return currentWindow;
+  }
+
+  static wrap(win: fin.OpenFinWindow) {
+    const wrappedWin = new Window();
+    wrappedWin.innerWindow = win;
+    wrappedWin.id = win.uuid + ':' + win.name;
+    return wrappedWin;
   }
 }
 

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -277,6 +277,12 @@ declare namespace ssf {
      * @returns The window.
      */
     static getCurrentWindow(callback?: () => void, errorCallback?: () => void): Window;
+
+    /**
+     * Wraps a native container window with a ContainerJS window.
+     * @param window The native window to wrap.
+     */
+    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
   }
 
   /**
@@ -455,11 +461,5 @@ declare namespace ssf {
      * @returns A promise that resolves to nothing when the window has unmaximized.
      */
     unmaximize(): Promise<void>;
-
-    /**
-     * Wraps a native container window with a ContainerJS window.
-     * @param window The native window to wrap.
-     */
-    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
   }
 }

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -277,12 +277,6 @@ declare namespace ssf {
      * @returns The window.
      */
     static getCurrentWindow(callback?: () => void, errorCallback?: () => void): Window;
-
-    /**
-     * Wraps a native container window with a ContainerJS window.
-     * @param window The native window to wrap.
-     */
-    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
   }
 
   /**
@@ -461,5 +455,11 @@ declare namespace ssf {
      * @returns A promise that resolves to nothing when the window has unmaximized.
      */
     unmaximize(): Promise<void>;
+
+        /**
+     * Wraps a native container window with a ContainerJS window.
+     * @param window The native window to wrap.
+     */
+    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
   }
 }

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -456,7 +456,7 @@ declare namespace ssf {
      */
     unmaximize(): Promise<void>;
 
-        /**
+    /**
      * Wraps a native container window with a ContainerJS window.
      * @param window The native window to wrap.
      */

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -277,6 +277,12 @@ declare namespace ssf {
      * @returns The window.
      */
     static getCurrentWindow(callback?: () => void, errorCallback?: () => void): Window;
+
+    /**
+     * Wraps a native container window with a ContainerJS window.
+     * @param window The native window to wrap.
+     */
+    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
   }
 
   /**

--- a/packages/api-tests/test/window.core.spec.js
+++ b/packages/api-tests/test/window.core.spec.js
@@ -616,6 +616,31 @@ describe('WindowCore API', function(done) {
       return chainPromises(steps);
     });
 
+    it.only('Should wrap a native window in a containerjs window object #ssf.Window.wrap', function() {
+      const windowTitle = 'windownamewrap';
+      const windowOptions = getWindowOptions({
+        name: windowTitle
+      });
+
+      /* eslint-disable no-undef */
+      const wrapScript = (callback) => {
+        ssf.app.ready().then(() => {
+          const inner = ssf.Window.getCurrentWindow().innerWindow;
+          const win = ssf.Window.wrap(inner);
+          callback(win.innerWindow != null);
+        });
+      };
+      /* eslint-enable no-undef */
+
+      const steps = [
+        ...setupWindowSteps(windowOptions),
+        () => executeAsyncJavascript(app.client, wrapScript),
+        (result) => assert.equal(result.value, true)
+      ];
+
+      return chainPromises(steps);
+    });
+
     if (process.env.MOCHA_CONTAINER === 'electron') {
       it('Should return the id of the window #ssf.Window.getId #ssf.WindowCore.getId', function() {
         const windowTitle = 'windownameid';

--- a/packages/api-tests/test/window.spec.js
+++ b/packages/api-tests/test/window.spec.js
@@ -560,31 +560,6 @@ if (process.env.MOCHA_CONTAINER !== 'browser') {
 
         return chainPromises(steps);
       });
-
-      it('Should wrap a native window in a containerjs window object #ssf.Window.wrap', function() {
-        const windowTitle = 'windownamewrap';
-        const windowOptions = getWindowOptions({
-          name: windowTitle
-        });
-
-        /* eslint-disable no-undef */
-        const wrapScript = (callback) => {
-          ssf.app.ready().then(() => {
-            const inner = ssf.Window.getCurrentWindow().innerWindow;
-            const win = ssf.Window.wrap(inner);
-            callback(win.innerWindow != null);
-          });
-        };
-        /* eslint-enable no-undef */
-
-        const steps = [
-          ...setupWindowSteps(windowOptions),
-          () => executeAsyncJavascript(app.client, wrapScript),
-          (result) => assert.equal(result.value, true)
-        ];
-
-        return chainPromises(steps);
-      });
     });
 
     describe('New Window', function() {

--- a/packages/api-tests/test/window.spec.js
+++ b/packages/api-tests/test/window.spec.js
@@ -560,6 +560,31 @@ if (process.env.MOCHA_CONTAINER !== 'browser') {
 
         return chainPromises(steps);
       });
+
+      it('Should wrap a native window in a containerjs window object #ssf.Window.wrap', function() {
+        const windowTitle = 'windownamewrap';
+        const windowOptions = getWindowOptions({
+          name: windowTitle
+        });
+
+        /* eslint-disable no-undef */
+        const wrapScript = (callback) => {
+          ssf.app.ready().then(() => {
+            const inner = ssf.Window.getCurrentWindow().innerWindow;
+            const win = ssf.Window.wrap(inner);
+            callback(win.innerWindow != null);
+          });
+        };
+        /* eslint-enable no-undef */
+
+        const steps = [
+          ...setupWindowSteps(windowOptions),
+          () => executeAsyncJavascript(app.client, wrapScript),
+          (result) => assert.equal(result.value, true)
+        ];
+
+        return chainPromises(steps);
+      });
     });
 
     describe('New Window', function() {


### PR DESCRIPTION
Adds a wrap method onto the Window class, that allows wrapping a native container window with the ContainerJS window object. Mainly useful internally for methods such as `getParentWindow()`, where the native container method returns a native window that we need to convert to a ContainerJS window.