### PR TITLE
Add method to get window by id

### DIFF
--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -348,6 +348,13 @@ class Window implements ssf.Window {
     wrappedWindow.id = String(win.id);
     return wrappedWindow;
   }
+
+  static getById(id: string) {
+    if (!isNaN(parseInt(id))) {
+      return Window.wrap(BrowserWindow.fromId(parseInt(id)));
+    }
+    return null;
+  }
 }
 
 export default Window;

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -350,10 +350,14 @@ class Window implements ssf.Window {
   }
 
   static getById(id: string) {
-    if (!isNaN(parseInt(id))) {
-      return Window.wrap(BrowserWindow.fromId(parseInt(id)));
-    }
-    return null;
+    return new Promise<Window>(resolve => {
+      if (!isNaN(parseInt(id))) {
+        const bw = BrowserWindow.fromId(parseInt(id))
+        resolve(bw === null ? null : Window.wrap(bw));
+        return;
+      }
+      resolve(null);
+    });
   }
 }
 

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -538,26 +538,10 @@ class Window implements ssf.Window {
 
     let app = null;
     let existsPromise: Promise<void>;
-    if (id.match(new RegExp(idRegex))) {
-      existsPromise = appExists(id.split(':')[0]).then((exists) => {
-        if (!exists) {
-          app = null;
-        } else {
-          app = fin.desktop.Application.wrap(id.split(':')[0]);
-        }
-      });
-    } else {
-      // Assume just app id was passed in
-      existsPromise = appExists(id).then((exists) => {
-        if (!exists) {
-          app = null;
-        } else {
-          app = fin.desktop.Application.wrap(id);
-        }
-      });
-    }
-
-    return existsPromise.then(() => {
+    const uuid = id.match(new RegExp(idRegex)) ? id.split(':')[0] : id;
+    return appExists(uuid).then((exists) => {
+      app = exists ? fin.desktop.Application.wrap(uuid) : null;
+    }).then(() => {
       if (app) {
         const win = app.getWindow();
         return Window.wrap(win);

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -242,9 +242,7 @@ class Window implements ssf.Window {
         fin.desktop.InterApplicationBus.unsubscribe('*' , 'ssf-child-windows', subscribeListener);
         const children = [];
         names.forEach((name) => {
-          const app = fin.desktop.Application.wrap(name);
-          const win = app.getWindow();
-          const childWin = Window.wrap(win);
+          const childWin = Window.getById(name);
           children.push(childWin);
         });
         resolve(children);
@@ -282,9 +280,7 @@ class Window implements ssf.Window {
           resolve(null);
           return;
         }
-        const app = fin.desktop.Application.wrap(name);
-        const win = app.getWindow();
-        const parentWin = Window.wrap(win);
+        const parentWin = Window.getById(name);
         resolve(parentWin);
       };
 
@@ -523,6 +519,25 @@ class Window implements ssf.Window {
     wrappedWin.innerWindow = win;
     wrappedWin.id = win.uuid + ':' + win.name;
     return wrappedWin;
+  }
+
+  static getById(id: string) {
+    const idRegex = '(' +    // Start group 1
+            '[\w\d-]+' +     // At least 1 word character, digit or dash
+            ')' +            // End group 1
+            ':' +            // colon
+            '\\1';            // Same string that was matched in group 1
+
+    let app = null;
+    if (id.match(new RegExp(idRegex))) {
+      app = fin.desktop.Application.wrap(id.split(':')[0]);
+    } else {
+      // Assume just app id was passed in
+      app = fin.desktop.Application.wrap(id);
+    }
+
+    const win = app.getWindow();
+    return Window.wrap(win);
   }
 }
 

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -283,6 +283,12 @@ declare namespace ssf {
      * @param window The native window to wrap.
      */
     static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
+
+    /**
+     * Get the window object with a particular id. Returns null if no window with that id exists.
+     * @param id The id of the window.
+     */
+    static getById(id: string): Window;
   }
 
   /**

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -277,18 +277,6 @@ declare namespace ssf {
      * @returns The window.
      */
     static getCurrentWindow(callback?: () => void, errorCallback?: () => void): Window;
-
-    /**
-     * Wraps a native container window with a ContainerJS window.
-     * @param window The native window to wrap.
-     */
-    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
-
-    /**
-     * Get the window object with a particular id. Returns null if no window with that id exists.
-     * @param id The id of the window.
-     */
-    static getById(id: string): Window;
   }
 
   /**
@@ -467,5 +455,17 @@ declare namespace ssf {
      * @returns A promise that resolves to nothing when the window has unmaximized.
      */
     unmaximize(): Promise<void>;
+
+    /**
+     * Wraps a native container window with a ContainerJS window.
+     * @param window The native window to wrap.
+     */
+    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
+
+    /**
+     * Get the window object with a particular id. Returns null if no window with that id exists.
+     * @param id The id of the window.
+     */
+    static getById(id: string): Window;
   }
 }

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -277,6 +277,12 @@ declare namespace ssf {
      * @returns The window.
      */
     static getCurrentWindow(callback?: () => void, errorCallback?: () => void): Window;
+
+    /**
+     * Wraps a native container window with a ContainerJS window.
+     * @param window The native window to wrap.
+     */
+    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
   }
 
   /**
@@ -457,15 +463,9 @@ declare namespace ssf {
     unmaximize(): Promise<void>;
 
     /**
-     * Wraps a native container window with a ContainerJS window.
-     * @param window The native window to wrap.
-     */
-    static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
-
-    /**
      * Get the window object with a particular id. Returns null if no window with that id exists.
      * @param id The id of the window.
      */
-    static getById(id: string): Window;
+    static getById(id: string): Promise<Window>;
   }
 }

--- a/packages/api-tests/test/window.core.spec.js
+++ b/packages/api-tests/test/window.core.spec.js
@@ -616,7 +616,7 @@ describe('WindowCore API', function(done) {
       return chainPromises(steps);
     });
 
-    it.only('Should wrap a native window in a containerjs window object #ssf.Window.wrap', function() {
+    it('Should wrap a native window in a containerjs window object #ssf.Window.wrap', function() {
       const windowTitle = 'windownamewrap';
       const windowOptions = getWindowOptions({
         name: windowTitle

--- a/packages/api-tests/test/window.spec.js
+++ b/packages/api-tests/test/window.spec.js
@@ -109,6 +109,58 @@ if (process.env.MOCHA_CONTAINER !== 'browser') {
         return chainPromises(steps);
       });
 
+      it('Should get a window by its id #ssf.Window.getById', function() {
+        const windowTitle = 'windownamegetbyid';
+        const windowOptions = getWindowOptions({
+          name: windowTitle
+        });
+
+        /* eslint-disable no-undef */
+        const idScript = (callback) => {
+          ssf.app.ready().then(() => {
+            const id = window.newWin.getId();
+            const win = ssf.Window.getById(id);
+            callback(win !== null);
+          });
+        };
+        /* eslint-enable no-undef */
+
+        const steps = [
+          ...setupWindowSteps(windowOptions),
+          () => selectWindow(app.client, 0),
+          () => executeAsyncJavascript(app.client, idScript),
+          (result) => assert.equal(result.value, true)
+        ];
+
+        return chainPromises(steps);
+      });
+
+      it('Should return null if no window with id exists #ssf.Window.getById', function() {
+        const windowTitle = 'windownamegetbyidwrong';
+        const windowOptions = getWindowOptions({
+          name: windowTitle
+        });
+
+        /* eslint-disable no-undef */
+        const idScript = (callback) => {
+          ssf.app.ready().then(() => {
+            ssf.Window.getById('thisiswrong').then(win => {
+              callback(win === null);
+            });
+          });
+        };
+        /* eslint-enable no-undef */
+
+        const steps = [
+          ...setupWindowSteps(windowOptions),
+          () => selectWindow(app.client, 0),
+          () => executeAsyncJavascript(app.client, idScript),
+          (result) => assert.equal(result.value, true)
+        ];
+
+        return chainPromises(steps);
+      });
+
       it('Should return the maximum width #ssf.Window.getMaximumSize', function() {
         const windowTitle = 'windownamemaxwidth';
         const maxWidth = 500;


### PR DESCRIPTION
Builds on the work that @kirilpopov did in #171 ([see method](https://github.com/symphonyoss/ContainerJS/pull/171/files#diff-9c41d64a6a03fd01f24706ed86e50b7eR19)). Currently just uses a static method on the window class, but we could move this into a separate class (like the initial PR) if necessary.