### PR TITLE
Add get all method to window api

### DIFF
--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -361,11 +361,7 @@ class Window implements ssf.Window {
   }
 
   static getAll() {
-    return new Promise<Window[]>(resolve => {
-      const windows = [];
-      BrowserWindow.getAllWindows().forEach((win) => windows.push(Window.wrap(win)));
-      resolve(windows);
-    });
+    return new Promise<Window[]>(resolve => resolve(BrowserWindow.getAllWindows().map(Window.wrap)));
   }
 }
 

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -359,6 +359,14 @@ class Window implements ssf.Window {
       resolve(null);
     });
   }
+
+  static getAll() {
+    return new Promise<Window[]>(resolve => {
+      const windows = [];
+      BrowserWindow.getAllWindows().forEach((win) => windows.push(Window.wrap(win)));
+      resolve(windows);
+    });
+  }
 }
 
 export default Window;

--- a/packages/api-openfin/src/main-process.ts
+++ b/packages/api-openfin/src/main-process.ts
@@ -67,6 +67,17 @@ const mainWindowCode = () => {
     });
   };
 
+  const getAllWindows = (node) => {
+    let windows = [];
+    node.forEach((win) => {
+      windows.push(win.name);
+      if (node.children) {
+        windows.concat(getAllWindows(node.children));
+      }
+    });
+    return windows;
+  };
+
   fin.desktop.InterApplicationBus.subscribe('*', 'ssf-new-window', (data) => {
     const app = fin.desktop.Application.wrap(data.windowName);
     app.getWindow().addEventListener('closed', () => {
@@ -105,6 +116,11 @@ const mainWindowCode = () => {
   fin.desktop.InterApplicationBus.subscribe('*', 'ssf-get-child-windows', (name, uuid) => {
     const children = getChildWindows(name, childTree);
     fin.desktop.InterApplicationBus.send(uuid, 'ssf-child-windows', children);
+  });
+
+  fin.desktop.InterApplicationBus.subscribe('*', 'ssf-get-all-windows', (data, uuid) => {
+    const windows = getAllWindows(childTree);
+    fin.desktop.InterApplicationBus.send(uuid, 'ssf-all-windows', windows);
   });
 
   fin.desktop.Window.getCurrent().addEventListener('close-requested', () => {

--- a/packages/api-openfin/src/main-process.ts
+++ b/packages/api-openfin/src/main-process.ts
@@ -71,8 +71,8 @@ const mainWindowCode = () => {
     let windows = [];
     node.forEach((win) => {
       windows.push(win.name);
-      if (node.children) {
-        windows.concat(getAllWindows(node.children));
+      if (win.children) {
+        windows = windows.concat(getAllWindows(win.children));
       }
     });
     return windows;

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -549,6 +549,25 @@ class Window implements ssf.Window {
       return null;
     });
   }
+
+  static getAll() {
+    return new Promise<Window[]>((resolve) => {
+      const subscribeListener = (appUuids) => {
+        fin.desktop.InterApplicationBus.unsubscribe('*', 'ssf-all-windows', subscribeListener);
+        const windows = [];
+        if (appUuids.length > 0) {
+          appUuids.forEach((uuid) => {
+            windows.push(Window.getById(uuid));
+          });
+        }
+
+        resolve(windows);
+      };
+
+      fin.desktop.InterApplicationBus.publish('ssf-get-all-windows', '');
+      fin.desktop.InterApplicationBus.subscribe('*' , 'ssf-all-windows', subscribeListener);
+    });
+  }
 }
 
 export default Window;

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -555,13 +555,16 @@ class Window implements ssf.Window {
       const subscribeListener = (appUuids) => {
         fin.desktop.InterApplicationBus.unsubscribe('*', 'ssf-all-windows', subscribeListener);
         const windows = [];
+        const promises = [];
         if (appUuids.length > 0) {
           appUuids.forEach((uuid) => {
-            windows.push(Window.getById(uuid));
+            promises.push(Window.getById(uuid).then((win) => windows.push(win)));
           });
         }
 
-        resolve(windows);
+        Promise.all(promises).then(() => {
+          resolve(windows);
+        });
       };
 
       fin.desktop.InterApplicationBus.publish('ssf-get-all-windows', '');

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -287,7 +287,7 @@ declare namespace ssf {
     /**
      * Returns all of the current windows.
      */
-    static getAll(): Array<Window>;
+    static getAll(): Promise<Array<Window>>;
   }
 
    /**

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -283,11 +283,6 @@ declare namespace ssf {
      * @param window The native window to wrap.
      */
     static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
-
-    /**
-     * Returns all of the current windows.
-     */
-    static getAll(): Promise<Array<Window>>;
   }
 
    /**
@@ -471,6 +466,11 @@ declare namespace ssf {
      * Get the window object with a particular id. Returns null if no window with that id exists.
      * @param id The id of the window.
      */
-    static getById(id: string): Promise<Window>;
+    static getById(id: string): Window;
+
+    /**
+     * Returns all of the current windows.
+     */
+    static getAll(): Promise<Array<Window>>;
   }
 }

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -466,7 +466,7 @@ declare namespace ssf {
      * Get the window object with a particular id. Returns null if no window with that id exists.
      * @param id The id of the window.
      */
-    static getById(id: string): Window;
+    static getById(id: string): Promise<Window>;
 
     /**
      * Returns all of the current windows.

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -283,6 +283,11 @@ declare namespace ssf {
      * @param window The native window to wrap.
      */
     static wrap(window: Electron.BrowserWindow | fin.OpenFinWindow | BrowserWindow): Window;
+
+    /**
+     * Returns all of the current windows.
+     */
+    static getAll(): Array<Window>;
   }
 
    /**

--- a/packages/api-tests/test/window.spec.js
+++ b/packages/api-tests/test/window.spec.js
@@ -81,6 +81,31 @@ if (process.env.MOCHA_CONTAINER !== 'browser') {
 
       });
 
+      it('Should get all open windows #ssf.Window.getAll', function() {
+        const windowTitle = 'windownamegetall';
+        const windowOptions = getWindowOptions({
+          name: windowTitle
+        });
+
+        /* eslint-disable no-undef */
+        const allScript = (callback) => {
+          ssf.app.ready().then(() => {
+            ssf.Window.getAll().then((windows) => {
+              callback(windows.length);
+            });
+          });
+        };
+        /* eslint-enable no-undef */
+
+        const steps = [
+          ...setupWindowSteps(windowOptions),
+          () => executeAsyncJavascript(app.client, allScript),
+          (result) => assert.equal(result.value, 2)
+        ];
+
+        return chainPromises(steps);
+      });
+
       it('Should get the bounds of the window #ssf.Window.getBounds', function() {
         const windowTitle = 'windownamegetbounds';
         const x = 50;


### PR DESCRIPTION
Implements `Window.getAll` which is similar to @kirilpopov suggestion [here](https://github.com/symphonyoss/ContainerJS/pull/171/files#diff-9c41d64a6a03fd01f24706ed86e50b7eR11).