### PR TITLE
Add types to API typescript files

### DIFF
--- a/packages/api-browser/index.ts
+++ b/packages/api-browser/index.ts
@@ -1,9 +1,9 @@
-import app from './src/app';
-import MessageService from './src/message-service';
-import ScreenSnippet from './src/screen-snippet';
-import Window from './src/window';
-import Notification from './src/notification';
-import Screen from './src/screen';
+import { app } from './src/app';
+import { MessageService }  from './src/message-service';
+import { ScreenSnippet } from './src/screen-snippet';
+import { Window } from './src/window';
+import { BrowserNotification as Notification } from './src/notification';
+import { Screen } from './src/screen';
 
 export {
   app,

--- a/packages/api-browser/src/accessible-windows.ts
+++ b/packages/api-browser/src/accessible-windows.ts
@@ -1,6 +1,6 @@
-const accessibleWindows = {};
+const accessibleWindows: Map<string, Window> = new Map();
 
-// if we have an opener, we are not the parent so we need to add it as a window
+// If we have an opener, we are not the parent so we need to add it as a window
 if (window.opener) {
   // The reference to the opener is not the full window object, so there is no onclose handler available
   accessibleWindows['parent'] = window.opener;

--- a/packages/api-browser/src/accessible-windows.ts
+++ b/packages/api-browser/src/accessible-windows.ts
@@ -9,12 +9,12 @@ if (window.opener) {
 }
 
 export const getAccessibleWindows = () => accessibleWindows;
-export const getAccessibleWindow = (name) => accessibleWindows[name];
+export const getAccessibleWindow = (name: string) => accessibleWindows[name];
 
-export const addAccessibleWindow = (name, win) => {
+export const addAccessibleWindow = (name: string, win: Window) => {
   accessibleWindows[name] = win;
 };
 
-export const removeAccessibleWindow = (name) => {
+export const removeAccessibleWindow = (name: string) => {
   delete accessibleWindows[name];
 };

--- a/packages/api-browser/src/app.ts
+++ b/packages/api-browser/src/app.ts
@@ -1,5 +1,5 @@
-const ready = () => Promise.resolve();
-
-export default {
-  ready
-};
+export class app {
+  static ready() {
+    return Promise.resolve();
+  }
+}

--- a/packages/api-browser/src/message-service.ts
+++ b/packages/api-browser/src/message-service.ts
@@ -1,9 +1,9 @@
-import Window from './window';
+import { Window } from './window';
 import { getAccessibleWindow } from './accessible-windows';
 
 const listenerMap = new Map();
 
-class MessageService implements ssf.MessageService {
+export class MessageService implements ssf.MessageService {
   static send(windowId: string, topic: string, message: any) {
     const win = getAccessibleWindow(windowId);
     const senderId = Window.getCurrentWindow().getId();
@@ -37,7 +37,7 @@ class MessageService implements ssf.MessageService {
     let deleteKey = null;
 
     // We cant use listenerMap.has() here because reconstructing the key from the arguments is a different object
-    // i.e. {} !== {}
+    // I.e. {} !== {}
     listenerMap.forEach((value, key) => {
       if (key.windowId === windowId && key.topic === topic && key.listener === listener) {
         window.removeEventListener('message', listener);
@@ -48,5 +48,3 @@ class MessageService implements ssf.MessageService {
     listenerMap.delete(deleteKey);
   }
 }
-
-export default MessageService;

--- a/packages/api-browser/src/message-service.ts
+++ b/packages/api-browser/src/message-service.ts
@@ -4,7 +4,7 @@ import { getAccessibleWindow } from './accessible-windows';
 const listenerMap = new Map();
 
 class MessageService implements ssf.MessageService {
-  static send(windowId, topic, message) {
+  static send(windowId: string, topic: string, message: any) {
     const win = getAccessibleWindow(windowId);
     const senderId = Window.getCurrentWindow().getId();
     if (win) {
@@ -16,7 +16,7 @@ class MessageService implements ssf.MessageService {
     }
   }
 
-  static subscribe(windowId, topic, listener) {
+  static subscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
     const receiveMessage = (event) => {
       if ((windowId === '*' || windowId === event.data.senderId) && topic === event.data.topic) {
         listener(event.data.message, event.data.senderId);
@@ -33,7 +33,7 @@ class MessageService implements ssf.MessageService {
     }, receiveMessage);
   }
 
-  static unsubscribe(windowId, topic, listener) {
+  static unsubscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
     let deleteKey = null;
 
     // We cant use listenerMap.has() here because reconstructing the key from the arguments is a different object

--- a/packages/api-browser/src/notification.ts
+++ b/packages/api-browser/src/notification.ts
@@ -1,6 +1,6 @@
 import { Emitter } from 'containerjs-api-utility';
 
-class BrowserNotification extends Emitter implements ssf.Notification {
+export class BrowserNotification extends Emitter implements ssf.Notification {
   innerNotification: Notification;
 
   constructor(title: string, options: ssf.NotificationOptions) {
@@ -20,5 +20,3 @@ class BrowserNotification extends Emitter implements ssf.Notification {
     return Notification.requestPermission();
   }
 }
-
-export default BrowserNotification;

--- a/packages/api-browser/src/screen-snippet.ts
+++ b/packages/api-browser/src/screen-snippet.ts
@@ -1,11 +1,9 @@
 import 'html2canvas';
 declare let html2canvas: any;
 
-class ScreenSnippet implements ssf.ScreenSnippet {
+export class ScreenSnippet implements ssf.ScreenSnippet {
   capture() {
     return html2canvas(document.body)
       .then((canvas) => canvas.toDataURL());
   }
 }
-
-export default ScreenSnippet;

--- a/packages/api-browser/src/screen.ts
+++ b/packages/api-browser/src/screen.ts
@@ -15,12 +15,10 @@ const browserDisplayMap = (display: BrowserScreen, primary: boolean): ssf.Displa
   };
 };
 
-class Screen implements ssf.Screen {
+export class Screen implements ssf.Screen {
   static getDisplays() {
     return new Promise<ssf.Display[]>(resolve => {
       resolve([browserDisplayMap(window.screen, true)]);
     });
   }
 }
-
-export default Screen;

--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -12,7 +12,7 @@ const getWindowOffsets = (win) => {
     return [Math.floor(xOffset), Math.floor(yOffset)];
 };
 
-class Window extends Emitter implements ssf.WindowCore {
+export class Window extends Emitter implements ssf.WindowCore {
   children: ssf.Window[];
   innerWindow: any;
   id: string;
@@ -205,5 +205,3 @@ const eventMap = {
   'message': 'message',
   'show': 'load'
 };
-
-export default Window;

--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -17,7 +17,7 @@ class Window extends Emitter implements ssf.WindowCore {
   innerWindow: any;
   id: string;
 
-  constructor(options?, callback?, errorCallback?) {
+  constructor(options?: ssf.WindowOptions, callback?: (win: Window) => void, errorCallback?: (err?: any) => void) {
     super();
     this.children = [];
 
@@ -115,7 +115,7 @@ class Window extends Emitter implements ssf.WindowCore {
     return this.asPromise<boolean>(() => true);
   }
 
-  loadURL(url) {
+  loadURL(url: string) {
     return this.asPromise<void>(() => location.href = url);
   }
 
@@ -123,18 +123,18 @@ class Window extends Emitter implements ssf.WindowCore {
     return this.asPromise<void>(() => location.reload());
   }
 
-  setBounds(bounds) {
+  setBounds(bounds: ssf.Rectangle) {
     return this.asPromise<void>(() => {
       this.innerWindow.moveTo(bounds.x, bounds.y);
       this.innerWindow.resizeTo(bounds.width, bounds.height);
     });
   }
 
-  setPosition(x, y) {
+  setPosition(x: number, y: number) {
     return this.asPromise<void>(() => this.innerWindow.moveTo(x, y));
   }
 
-  setSize(width, height) {
+  setSize(width: number, height: number) {
      return this.asPromise<void>(() => this.innerWindow.resizeTo(width, height));
   }
 
@@ -146,7 +146,7 @@ class Window extends Emitter implements ssf.WindowCore {
     this.innerWindow.removeEventListener(eventMap[event], listener);
   }
 
-  postMessage(message) {
+  postMessage(message: any) {
     this.innerWindow.postMessage(message, '*');
   }
 
@@ -154,7 +154,7 @@ class Window extends Emitter implements ssf.WindowCore {
     return new Promise<ssf.Window[]>(resolve => resolve(this.children));
   }
 
-  asPromise<T>(fn): Promise<T> {
+  asPromise<T>(fn: (...args: any[]) => any): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       if (this.innerWindow) {
         resolve(fn());
@@ -164,7 +164,7 @@ class Window extends Emitter implements ssf.WindowCore {
     });
   }
 
-  static getCurrentWindow(callback?: any, errorCallback?: any) {
+  static getCurrentWindow(callback?: (win: Window) => void, errorCallback?: (err?: any) => void) {
     if (currentWindow) {
       return currentWindow;
     }
@@ -181,7 +181,7 @@ class Window extends Emitter implements ssf.WindowCore {
   }
 }
 
-const objectToFeaturesString = (features) => {
+const objectToFeaturesString = (features: ssf.WindowOptions) => {
   return Object.keys(features).map((key) => {
     let value = features[key];
 

--- a/packages/api-electron/preload.ts
+++ b/packages/api-electron/preload.ts
@@ -1,9 +1,9 @@
-import app from './src/preload/app';
-import MessageService from './src/preload/message-service';
-import ScreenSnippet from './src/preload/screen-snippet';
-import Window from './src/preload/window';
-import Notification from './src/preload/notification';
-import Screen from './src/preload/screen';
+import { app } from './src/preload/app';
+import { MessageService } from './src/preload/message-service';
+import { ScreenSnippet } from './src/preload/screen-snippet';
+import { Window } from './src/preload/window';
+import { Notification } from './src/preload/notification';
+import { Screen } from './src/preload/screen';
 
 export {
   app,

--- a/packages/api-electron/src/preload/app.ts
+++ b/packages/api-electron/src/preload/app.ts
@@ -1,7 +1,5 @@
-class app implements ssf.App {
+export class app implements ssf.App {
   static ready() {
     return Promise.resolve();
   }
 }
-
-export default app;

--- a/packages/api-electron/src/preload/message-service.ts
+++ b/packages/api-electron/src/preload/message-service.ts
@@ -4,7 +4,7 @@ import { IpcMessages } from '../common/constants';
 const listenerMap = new Map();
 
 class MessageService implements ssf.MessageService {
-  static send(windowId, topic, message) {
+  static send(windowId: string, topic: string, message: any) {
     ipc.send(IpcMessages.IPC_SSF_SEND_MESSAGE, {
       windowId,
       topic,
@@ -12,7 +12,7 @@ class MessageService implements ssf.MessageService {
     });
   }
 
-  static subscribe(windowId, topic, listener) {
+  static subscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
     const receiveMessage = (event, message, sender) => {
       // Check this was from the correct window
       if (windowId === sender.toString() || windowId === '*') {
@@ -30,7 +30,7 @@ class MessageService implements ssf.MessageService {
     }, receiveMessage);
   }
 
-  static unsubscribe(windowId, topic, listener) {
+  static unsubscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
     let deleteKey = null;
 
     // We cant use listenerMap.has() here because reconstructing the key from the arguments is a different object

--- a/packages/api-electron/src/preload/message-service.ts
+++ b/packages/api-electron/src/preload/message-service.ts
@@ -3,7 +3,7 @@ import { IpcMessages } from '../common/constants';
 
 const listenerMap = new Map();
 
-class MessageService implements ssf.MessageService {
+export class MessageService implements ssf.MessageService {
   static send(windowId: string, topic: string, message: any) {
     ipc.send(IpcMessages.IPC_SSF_SEND_MESSAGE, {
       windowId,
@@ -34,7 +34,7 @@ class MessageService implements ssf.MessageService {
     let deleteKey = null;
 
     // We cant use listenerMap.has() here because reconstructing the key from the arguments is a different object
-    // i.e. {} !== {}
+    // I.e. {} !== {}
     listenerMap.forEach((value, key) => {
       if (key.windowId === windowId && key.topic === topic && key.listener === listener) {
         ipc.removeListener(`${IpcMessages.IPC_SSF_SEND_MESSAGE}-${topic}`, value);
@@ -45,5 +45,3 @@ class MessageService implements ssf.MessageService {
     listenerMap.delete(deleteKey);
   }
 }
-
-export default MessageService;

--- a/packages/api-electron/src/preload/notification.ts
+++ b/packages/api-electron/src/preload/notification.ts
@@ -5,7 +5,7 @@ import { Uri, Emitter } from 'containerjs-api-utility';
 const PERMISSION_GRANTED: ssf.NotificationPermission = 'granted';
 
 // Image style moves the image below the icon and title/body,
-// to match the style of native notifications
+// To match the style of native notifications
 const imageStyle = {
         overflow:  'hidden',
         display:  'block',
@@ -15,7 +15,7 @@ const imageStyle = {
 const HEIGHT_WITHOUT_IMAGE = 65;
 const HEIGHT_WITH_IMAGE = 100;
 
-class Notification extends Emitter implements ssf.Notification {
+export class Notification extends Emitter implements ssf.Notification {
   constructor(title: string, options: ssf.NotificationOptions) {
     super();
 
@@ -41,5 +41,3 @@ class Notification extends Emitter implements ssf.Notification {
     return Promise.resolve(PERMISSION_GRANTED);
   }
 }
-
-export default Notification;

--- a/packages/api-electron/src/preload/screen-snippet.ts
+++ b/packages/api-electron/src/preload/screen-snippet.ts
@@ -1,6 +1,6 @@
 const remote = require('electron').remote;
 
-class ScreenSnippet implements ssf.ScreenSnippet {
+export class ScreenSnippet implements ssf.ScreenSnippet {
   capture() {
     return new Promise<string>((resolve) => {
       remote.getCurrentWindow().capturePage((image: any) => {
@@ -10,5 +10,3 @@ class ScreenSnippet implements ssf.ScreenSnippet {
     });
   }
 }
-
-export default ScreenSnippet;

--- a/packages/api-electron/src/preload/screen.ts
+++ b/packages/api-electron/src/preload/screen.ts
@@ -11,7 +11,7 @@ const electronDisplayMap = (display: Electron.Display, primary: boolean): ssf.Di
   };
 };
 
-class Screen implements ssf.Screen {
+export class Screen implements ssf.Screen {
   static getDisplays() {
     return new Promise<ssf.Display[]>(resolve => {
       const primaryDisplay = electronDisplayMap(ElectronScreen.getPrimaryDisplay(), true);
@@ -23,5 +23,3 @@ class Screen implements ssf.Screen {
     });
   }
 }
-
-export default Screen;

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -5,13 +5,13 @@ const {
 const { BrowserWindow, nativeImage } = remote;
 const request = remote.require('request');
 import { Emitter } from 'containerjs-api-utility';
-import MessageService from './message-service';
+import { MessageService } from './message-service';
 import { IpcMessages } from '../common/constants';
 
 let currentWindow = null;
 const isUrlPattern = /^https?:\/\//i;
 
-class Window extends Emitter implements ssf.Window {
+export class Window extends Emitter implements ssf.Window {
   innerWindow: Electron.BrowserWindow;
   id: string;
 
@@ -39,7 +39,7 @@ class Window extends Emitter implements ssf.Window {
         // File at root
         electronOptions.url = location.origin + electronOptions.url;
       } else {
-        // relative to current file
+        // Relative to current file
         const pathSections = location.pathname.split('/').filter(x => x);
         pathSections.splice(-1);
         const currentPath = pathSections.join('/');
@@ -252,7 +252,7 @@ class Window extends Emitter implements ssf.Window {
   }
 
   postMessage(message: any) {
-    MessageService.send(this.innerWindow.id, 'ssf-window-message', message);
+    MessageService.send(this.id, 'ssf-window-message', message);
   }
 
   getChildWindows() {
@@ -299,5 +299,3 @@ class Window extends Emitter implements ssf.Window {
     return new Promise<Window[]>(resolve => resolve(BrowserWindow.getAllWindows().map(Window.wrap)));
   }
 }
-
-export default Window;

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -69,7 +69,7 @@ class Window extends Emitter implements ssf.Window {
     return this.asPromise<void>(this.innerWindow.close);
   }
 
-  flashFrame(flag) {
+  flashFrame(flag: boolean) {
     return this.asPromise<void>(this.innerWindow.flashFrame, flag);
   }
 
@@ -153,7 +153,7 @@ class Window extends Emitter implements ssf.Window {
     return this.asPromise<boolean>(this.innerWindow.isVisible);
   }
 
-  loadURL(url) {
+  loadURL(url: string) {
     return this.asPromise<void>(this.innerWindow.loadURL, url);
   }
 
@@ -173,15 +173,15 @@ class Window extends Emitter implements ssf.Window {
     return this.asPromise<void>(this.innerWindow.restore);
   }
 
-  setAlwaysOnTop(alwaysOnTop) {
+  setAlwaysOnTop(alwaysOnTop: boolean) {
     return this.asPromise<void>(this.innerWindow.setAlwaysOnTop, alwaysOnTop);
   }
 
-  setBounds(bounds) {
+  setBounds(bounds: ssf.Rectangle) {
     return this.asPromise<void>(this.innerWindow.setBounds, bounds);
   }
 
-  setIcon(icon) {
+  setIcon(icon: string) {
     const req = request.defaults({ encoding: null });
     return new Promise<void>((resolve, reject) => {
         req.get(icon, (err, res, body) => {
@@ -197,35 +197,35 @@ class Window extends Emitter implements ssf.Window {
     });
   }
 
-  setMaximizable(maximizable) {
+  setMaximizable(maximizable: boolean) {
     return this.asPromise<void>(this.innerWindow.setMaximizable, maximizable);
   }
 
-  setMaximumSize(width, height) {
+  setMaximumSize(width: number, height: number) {
     return this.asPromise<void>(this.innerWindow.setMaximumSize, width, height);
   }
 
-  setMinimizable(minimizable) {
+  setMinimizable(minimizable: boolean) {
     return this.asPromise<void>(this.innerWindow.setMinimizable, minimizable);
   }
 
-  setMinimumSize(width, height) {
+  setMinimumSize(width: number, height: number) {
     return this.asPromise<void>(this.innerWindow.setMinimumSize, width, height);
   }
 
-  setPosition(x, y) {
+  setPosition(x: number, y: number) {
     return this.asPromise<void>(this.innerWindow.setPosition, x, y);
   }
 
-  setResizable(resizable) {
+  setResizable(resizable: boolean) {
     return this.asPromise<void>(this.innerWindow.setResizable, resizable);
   }
 
-  setSize(width, height) {
+  setSize(width: number, height: number) {
     return this.asPromise<void>(this.innerWindow.setSize, width, height);
   }
 
-  setSkipTaskbar(skipTaskbar) {
+  setSkipTaskbar(skipTaskbar: boolean) {
     return this.asPromise<void>(this.innerWindow.setSkipTaskbar, skipTaskbar);
   }
 
@@ -237,7 +237,7 @@ class Window extends Emitter implements ssf.Window {
     return this.asPromise<void>(this.innerWindow.unmaximize);
   }
 
-  asPromise<T>(windowFunction, ...args): Promise<T> {
+  asPromise<T>(windowFunction: (...args: any[]) => any, ...args: any[]): Promise<T> {
     return new Promise<T>((resolve) => {
       resolve(windowFunction(...args));
     });
@@ -251,7 +251,7 @@ class Window extends Emitter implements ssf.Window {
     this.innerWindow.removeListener(event, listener);
   }
 
-  postMessage(message) {
+  postMessage(message: any) {
     MessageService.send(this.innerWindow.id, 'ssf-window-message', message);
   }
 
@@ -268,7 +268,7 @@ class Window extends Emitter implements ssf.Window {
     });
   }
 
-  static getCurrentWindow(callback, errorCallback) {
+  static getCurrentWindow(callback: (win: Window) => void, errorCallback: (err?: any) => void) {
     if (currentWindow) {
       return currentWindow;
     }

--- a/packages/api-openfin/index.ts
+++ b/packages/api-openfin/index.ts
@@ -1,9 +1,9 @@
-import app from './src/app';
-import MessageService from './src/message-service';
-import ScreenSnippet from './src/screen-snippet';
-import Window from './src/window';
-import Notification from './src/notification';
-import Screen from './src/screen';
+import { app } from './src/app';
+import { MessageService } from './src/message-service';
+import { ScreenSnippet } from './src/screen-snippet';
+import { Window } from './src/window';
+import { Notification } from './src/notification';
+import { Screen } from './src/screen';
 
 export {
   app,

--- a/packages/api-openfin/src/app.ts
+++ b/packages/api-openfin/src/app.ts
@@ -1,11 +1,9 @@
-import createMainProcess from './main-process';
+import { createMainProcess } from './main-process';
 
-class app implements ssf.App {
+export class app implements ssf.App {
   static ready() {
     return new Promise<void>((resolve) => {
       fin.desktop.main(() => createMainProcess(resolve));
     });
   }
 }
-
-export default app;

--- a/packages/api-openfin/src/app.ts
+++ b/packages/api-openfin/src/app.ts
@@ -2,7 +2,7 @@ import createMainProcess from './main-process';
 
 class app implements ssf.App {
   static ready() {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       fin.desktop.main(() => createMainProcess(resolve));
     });
   }

--- a/packages/api-openfin/src/main-process.ts
+++ b/packages/api-openfin/src/main-process.ts
@@ -10,7 +10,7 @@ type NewWindowMessage = {
   parentName: string
 };
 // Code that is "evaled" when the main window has been opened, sets up
-// all the InterApplicationBus listeners for window events to keep track of state
+// All the InterApplicationBus listeners for window events to keep track of state
 const mainWindowCode = () => {
   const childTree: ChildTree[] = [];
 
@@ -138,7 +138,7 @@ const mainWindowCode = () => {
   });
 };
 
-const createMainProcess = (done: (err?: any) => void) => {
+export const createMainProcess = (done: (err?: any) => void) => {
   // Populate the current window variable
   ssf.Window.getCurrentWindow();
 
@@ -147,7 +147,7 @@ const createMainProcess = (done: (err?: any) => void) => {
   });
 
   // Create the main window, if the window already exists, the success callback isn't ran
-  // and the already open window is returned
+  // And the already open window is returned
   const app = new fin.desktop.Application({
     url: 'about:blank',
     name: 'mainWindow',
@@ -157,7 +157,7 @@ const createMainProcess = (done: (err?: any) => void) => {
     }
   }, () => {
     app.run(() => {
-      // executeJavaScript only takes a string, but writing the code as a string means we lose typescript checking
+      // Method executeJavaScript only takes a string, but writing the code as a string means we lose typescript checking
       const body = mainWindowCode.toString().slice(mainWindowCode.toString().indexOf('{') + 1, mainWindowCode.toString().lastIndexOf('}'));
       const mainWindow = app.getWindow();
       mainWindow.executeJavaScript(body, () => {
@@ -172,5 +172,3 @@ const createMainProcess = (done: (err?: any) => void) => {
     });
   }, (err) => done(err));
 };
-
-export default createMainProcess;

--- a/packages/api-openfin/src/message-service.ts
+++ b/packages/api-openfin/src/message-service.ts
@@ -1,4 +1,4 @@
-class MessageService implements ssf.MessageService {
+export class MessageService implements ssf.MessageService {
   // Window ID should be in the form 'application-uuid:window-name'
   static send(windowId: string, topic: string, message: any) {
     const [appId, windowName] = windowId.split(':');
@@ -30,5 +30,3 @@ class MessageService implements ssf.MessageService {
     }
   }
 }
-
-export default MessageService;

--- a/packages/api-openfin/src/message-service.ts
+++ b/packages/api-openfin/src/message-service.ts
@@ -1,6 +1,6 @@
 class MessageService implements ssf.MessageService {
   // Window ID should be in the form 'application-uuid:window-name'
-  static send(windowId, topic, message) {
+  static send(windowId: string, topic: string, message: any) {
     const [appId, windowName] = windowId.split(':');
 
     if (appId && windowName) {
@@ -10,7 +10,7 @@ class MessageService implements ssf.MessageService {
     }
   }
 
-  static subscribe(windowId, topic, listener) {
+  static subscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
     const [appId, windowName] = windowId.split(':');
 
     if (appId && windowName) {
@@ -20,7 +20,7 @@ class MessageService implements ssf.MessageService {
     }
   }
 
-  static unsubscribe(windowId, topic, listener) {
+  static unsubscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
     const [appId, windowName] = windowId.split(':');
 
     if (appId && windowName) {

--- a/packages/api-openfin/src/notification.ts
+++ b/packages/api-openfin/src/notification.ts
@@ -1,7 +1,7 @@
 import { Uri, Emitter } from 'containerjs-api-utility';
 const PERMISSION_GRANTED: ssf.NotificationPermission = 'granted';
 
-class Notification extends Emitter implements ssf.Notification {
+export class Notification extends Emitter implements ssf.Notification {
   constructor(title: string, options: ssf.NotificationOptions) {
     super();
 
@@ -16,7 +16,6 @@ class Notification extends Emitter implements ssf.Notification {
       icon: Uri.getAbsoluteUrl(options.icon)
      };
 
-    // eslint-disable-next-line no-new
     new fin.desktop.Notification({
       url: Uri.getAbsoluteUrl('notification.html'),
       message,
@@ -28,4 +27,3 @@ class Notification extends Emitter implements ssf.Notification {
     return Promise.resolve(PERMISSION_GRANTED);
   }
 }
-export default Notification;

--- a/packages/api-openfin/src/screen-snippet.ts
+++ b/packages/api-openfin/src/screen-snippet.ts
@@ -1,4 +1,4 @@
-class ScreenSnippet implements ssf.ScreenSnippet {
+export class ScreenSnippet implements ssf.ScreenSnippet {
   capture() {
     return new Promise<string>((resolve, reject) => {
       fin.desktop.Window.getCurrent()
@@ -6,5 +6,3 @@ class ScreenSnippet implements ssf.ScreenSnippet {
     });
   }
 }
-
-export default ScreenSnippet;

--- a/packages/api-openfin/src/screen.ts
+++ b/packages/api-openfin/src/screen.ts
@@ -13,7 +13,7 @@ const ofDisplayMap = (display: fin.MonitorInfoDetail, primary: boolean): ssf.Dis
   };
 };
 
-class Screen implements ssf.Screen {
+export class Screen implements ssf.Screen {
   static getDisplays() {
     return new Promise<ssf.Display[]>(resolve => {
       fin.desktop.System.getMonitorInfo((info) => {
@@ -25,5 +25,3 @@ class Screen implements ssf.Screen {
     });
   }
 }
-
-export default Screen;

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -1,6 +1,6 @@
 import { Emitter } from 'containerjs-api-utility';
-import MessageService from './message-service';
-import createMainProcess from './main-process';
+import { MessageService } from './message-service';
+import { createMainProcess } from './main-process';
 
 let currentWindow: Window = null;
 
@@ -132,7 +132,7 @@ const convertOptions = (options: ssf.WindowOptions): fin.WindowOptions => {
   return clonedOptions;
 };
 
-class Window extends Emitter implements ssf.Window {
+export class Window extends Emitter implements ssf.Window {
   innerWindow: fin.OpenFinWindow;
   id: string;
 
@@ -159,7 +159,7 @@ class Window extends Emitter implements ssf.Window {
         // File at root
         openFinOptions.url = location.origin + openFinOptions.url;
       } else {
-        // relative to current file
+        // Relative to current file
         const pathSections = location.pathname.split('/').filter(x => x);
         pathSections.splice(-1);
         const currentPath = pathSections.join('/');
@@ -466,7 +466,7 @@ class Window extends Emitter implements ssf.Window {
     const idRegex = '(' +    // Start group 1
             '[\w\d-]+' +     // At least 1 word character, digit or dash
             ')' +            // End group 1
-            ':' +            // colon
+            ':' +            // Colon
             '\\1';           // Same string that was matched in group 1
 
     let app = null;
@@ -505,5 +505,3 @@ class Window extends Emitter implements ssf.Window {
     });
   }
 }
-
-export default Window;

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -193,7 +193,7 @@ class Window extends Emitter implements ssf.Window {
     });
   }
 
-  asPromise<T>(fn: string, ...args): Promise<T> {
+  asPromise<T>(fn: string, ...args: any[]): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       if (this.innerWindow) {
         const openFinFunction = this.innerWindow[fn];
@@ -208,7 +208,7 @@ class Window extends Emitter implements ssf.Window {
     return this.asPromise<void>('blur');
   }
 
-  close(force = false) {
+  close(force: boolean = false) {
     return this.asPromise<void>('close', force)
       .then(() => {
         this.innerWindow = undefined;
@@ -350,7 +350,7 @@ class Window extends Emitter implements ssf.Window {
     return this.asPromise<boolean>('isShowing');
   }
 
-  loadURL(url) {
+  loadURL(url: string) {
     return this.asPromise<void>('executeJavaScript', `window.location = '${url}'`);
   }
 

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -434,7 +434,7 @@ class Window extends Emitter implements ssf.Window {
     this.innerWindow.removeEventListener(eventMap[event], listener);
   }
 
-  postMessage(message: string | object | any[]) {
+  postMessage(message: any) {
     MessageService.send(`${this.innerWindow.uuid}:${this.innerWindow.name}`, 'ssf-window-message', message);
   }
 

--- a/packages/api-specification/interface/openfin-extension.ts
+++ b/packages/api-specification/interface/openfin-extension.ts
@@ -9,5 +9,7 @@ declare namespace fin {
 
   interface WindowOptions {
     preload?: string;
+    title?: string;
+    shadow?: boolean;
   }
 }

--- a/packages/api-symphony-compatibility/index.ts
+++ b/packages/api-symphony-compatibility/index.ts
@@ -1,3 +1,3 @@
-import ssf from './src/mapping';
+import { map } from './src/mapping';
 
-export default ssf;
+export const ssf = map.ssf;

--- a/packages/api-symphony-compatibility/src/mapping.ts
+++ b/packages/api-symphony-compatibility/src/mapping.ts
@@ -1,6 +1,6 @@
 const containerjsSsf = ssf;
 
-namespace map {
+export namespace map {
   export class ssf {
     /** API defined at https://symphonyoss.atlassian.net/wiki/display/WGDWAPI/Activate+API */
     static activate(windowName: string) {
@@ -59,5 +59,3 @@ namespace map {
     }
   }
 }
-
-export default map.ssf;

--- a/packages/api-utility/index.ts
+++ b/packages/api-utility/index.ts
@@ -1,5 +1,5 @@
-import Uri from './src/uri';
-import Emitter from './src/emitter';
+import { Uri } from './src/uri';
+import { Emitter } from './src/emitter';
 
 export {
   Uri,

--- a/packages/api-utility/src/emitter.ts
+++ b/packages/api-utility/src/emitter.ts
@@ -18,7 +18,7 @@ abstract class Emitter implements ssf.EventEmitter {
     }
   }
 
-  addListener(event, listener) {
+  addListener(event: string, listener: (...args: any[]) => void) {
     if (this.eventListeners.has(event)) {
       const temp = this.eventListeners.get(event);
       temp.push(listener);
@@ -30,7 +30,7 @@ abstract class Emitter implements ssf.EventEmitter {
     return this;
   }
 
-  on(event, listener) {
+  on(event: string, listener: (...args: any[]) => void) {
     return this.addListener(event, listener);
   }
 
@@ -38,15 +38,15 @@ abstract class Emitter implements ssf.EventEmitter {
     return Array.from<string>(this.eventListeners.keys());
   }
 
-  listenerCount(event) {
+  listenerCount(event: string) {
     return this.eventListeners.has(event) ? this.eventListeners.get(event).length : 0;
   }
 
-  listeners(event) {
+  listeners(event: string) {
     return this.eventListeners.get(event);
   }
 
-  once(event, listener) {
+  once(event: string, listener: (...args: any[]) => void) {
     // Remove the listener once it is called
     const unsubscribeListener = (evt) => {
       this.removeListener(event, unsubscribeListener);
@@ -57,7 +57,7 @@ abstract class Emitter implements ssf.EventEmitter {
     return this;
   }
 
-  removeListener(event, listener) {
+  removeListener(event: string, listener: (...args: any[]) => void) {
     if (this.eventListeners.has(event)) {
       const listeners = this.eventListeners.get(event);
       const index = listeners.indexOf(listener);
@@ -73,7 +73,7 @@ abstract class Emitter implements ssf.EventEmitter {
     return this;
   }
 
-  removeAllListeners(eventName) {
+  removeAllListeners(eventName: string) {
     const removeAllListenersForEvent = (event) => {
       if (this.eventListeners.has(event)) {
         this.eventListeners.get(event).forEach((listener) => {

--- a/packages/api-utility/src/emitter.ts
+++ b/packages/api-utility/src/emitter.ts
@@ -1,4 +1,4 @@
-abstract class Emitter implements ssf.EventEmitter {
+export abstract class Emitter implements ssf.EventEmitter {
   eventListeners: Map<string, ((...args: any[]) => void)[]> = new Map();
 
   constructor() {
@@ -6,10 +6,10 @@ abstract class Emitter implements ssf.EventEmitter {
   }
 
   innerAddEventListener(event: string, listener: (...args: any[]) => void) {
-    // no-op default implementation to be overridden if required
+    // No-op default implementation to be overridden if required
   }
   innerRemoveEventListener(event: string, listener: (...args: any[]) => void) {
-    // no-op default implementation to be overridden if required
+    // No-op default implementation to be overridden if required
   }
 
   emit(event: string, data?: any) {
@@ -92,5 +92,3 @@ abstract class Emitter implements ssf.EventEmitter {
     return this;
   }
 }
-
-export default Emitter;

--- a/packages/api-utility/src/uri.ts
+++ b/packages/api-utility/src/uri.ts
@@ -1,6 +1,6 @@
 const isUrlPattern = /^https?:\/\//i;
 
-class Uri {
+export class Uri {
   static getAbsoluteUrl(url: string): string {
     if (url && !isUrlPattern.test(url)) {
       const path = url.startsWith('/')
@@ -12,5 +12,3 @@ class Uri {
     return url;
   }
 }
-
-export default Uri;

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,6 @@
             "spaces"
         ],
         "jsdoc-format": true,
-        "no-inferrable-types": true,
         "no-internal-module": true,
         "no-null-keyword": false,
         "no-switch-case-fall-through": true,
@@ -26,6 +25,12 @@
         ],
         "semicolon": [true, "always", "ignore-bound-class-methods"],
         "triple-equals": [true, "allow-null-check"],
+        "typedef": [
+            true,
+            "parameter",
+            "member-variable-declaration",
+            "property-declaration"
+        ],
         "typedef-whitespace": [
             true,
             {

--- a/tslint.json
+++ b/tslint.json
@@ -1,13 +1,17 @@
 {
     "rules": {
+        "arrow-return-shorthand": true,
         "comment-format": [true,
-            "check-space"
+            "check-space",
+            "check-uppercase"
         ],
-        "curly":[true, "ignore-same-line"],
+        "curly":[true],
+        "eofline": true,
         "indent": [true,
             "spaces"
         ],
         "jsdoc-format": true,
+        "no-default-export": true,
         "no-internal-module": true,
         "no-null-keyword": false,
         "no-switch-case-fall-through": true,
@@ -17,6 +21,9 @@
         "one-line": [true,
             "check-open-brace",
             "check-whitespace"
+        ],
+        "only-arrow-functions": [
+            true
         ],
         "prefer-const": true,
         "quotemark": [true,


### PR DESCRIPTION
Adds more types to the API, as well as adding some extra tslint rules. The new rules are:
* arrow-return-shorthand: Prefer `() => a` over `() => { return a; }`
* comment check-uppercase: Start comments with uppcase letter
* eofline: Force new line at end of file
* no-default-export: disable `export default Window` in favor of `export class Window`, see [here](https://github.com/palantir/tslint/issues/1182#issue-151780453)
* only-arrow-functions: Require functions to be ES6 arrow functions not old style `function() {}`
* typedef: require type definitions for parameters, member variables and properties.

Closes #115.
