### PR TITLE
Fix and standardise emitter `emit` parameters

### DIFF
--- a/packages/api-browser/package.json
+++ b/packages/api-browser/package.json
@@ -24,8 +24,7 @@
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
-    "html2canvas": "^0.5.0-beta4",
-    "typescript": "^2.3.2"
+    "html2canvas": "^0.5.0-beta4"
   },
   "devDependencies": {
     "containerjs-api-specification": "^0.0.3",
@@ -33,6 +32,7 @@
     "copyfiles": "^1.2.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.6",
-    "rollup-plugin-node-resolve": "^2.0.0"
+    "rollup-plugin-node-resolve": "^2.0.0",
+    "typescript": "^2.4.1"
   }
 }

--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -41,12 +41,6 @@ export class Window extends Emitter implements ssf.WindowCore {
       addAccessibleWindow(options.name, this.innerWindow);
     }
 
-    this.addListener('message', (e) => {
-      if (e.data) {
-        this.emit('message', e.data);
-      }
-    });
-
     if (callback) {
       callback(this);
     }

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -39,6 +39,6 @@
     "rollup": "^0.41.6",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "typescript": "^2.3.2"
+    "typescript": "^2.4.1"
   }
 }

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -18,8 +18,8 @@ export class Window extends Emitter implements ssf.Window {
   constructor(options?: ssf.WindowOptions, callback?: (window: Window) => void, errorCallback?: () => void) {
     super();
 
-    MessageService.subscribe('*', 'ssf-window-message', (...args) => {
-      this.emit('message', ...args);
+    MessageService.subscribe('*', 'ssf-window-message', (data?: any) => {
+      this.emit('message', { data });
     });
 
     if (!options) {

--- a/packages/api-openfin/package.json
+++ b/packages/api-openfin/package.json
@@ -29,7 +29,7 @@
     "copyfiles": "^1.2.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.6",
-    "typescript": "^2.3.2"
+    "typescript": "^2.4.1"
   },
   "bin": {
     "ssf-openfin": "./bin/ssf-openfin"

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -138,8 +138,8 @@ export class Window extends Emitter implements ssf.Window {
 
   constructor(options?: ssf.WindowOptions, callback?: (win: Window) => void, errorCallback?: (err?: any) => void) {
     super();
-    MessageService.subscribe('*', 'ssf-window-message', (...args) => {
-      this.emit('message', ...args);
+    MessageService.subscribe('*', 'ssf-window-message', (data?: any) => {
+      this.emit('message', { data });
     });
 
     if (!options) {

--- a/packages/api-symphony-compatibility/package.json
+++ b/packages/api-symphony-compatibility/package.json
@@ -40,6 +40,6 @@
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
     "rollup": "^0.43.0",
-    "typescript": "^2.3.4"
+    "typescript": "^2.4.1"
   }
 }

--- a/packages/api-tests/test/window.core.spec.js
+++ b/packages/api-tests/test/window.core.spec.js
@@ -709,7 +709,7 @@ describe('WindowCore API', function(done) {
           var eventName = `evt_${event}_count`;
           window[eventName] = [];
           var currentWin = ssf.Window.getCurrentWindow();
-          
+
           currentWin.addListener(event, evt => {
             window[eventName].push(evt.data);
             console.log(event);
@@ -744,8 +744,7 @@ describe('WindowCore API', function(done) {
         /* eslint-enable no-undef */
         return executeAsyncJavascript(app.client, script, event);
       };
-      
-      let childWindowId;
+
       const steps = [
         ...setupWindowSteps(windowOptions),
         () => addWindowListener('message'),

--- a/packages/api-tests/test/window.core.spec.js
+++ b/packages/api-tests/test/window.core.spec.js
@@ -695,7 +695,7 @@ describe('WindowCore API', function(done) {
       });
     }
 
-    it.only('Should emit a message event in the window #ssf.Window.postMessage #ssf.Window.postMessage', function() {
+    it('Should emit a message event in the window #ssf.Window.postMessage #ssf.WindowCore.postMessage', function() {
       const windowTitle = 'windownamepostmessage';
       const windowOptions = getWindowOptions({
         name: windowTitle
@@ -712,7 +712,6 @@ describe('WindowCore API', function(done) {
 
           currentWin.addListener(event, evt => {
             window[eventName].push(evt.data);
-            console.log(event);
           });
           callback();
         };

--- a/packages/api-utility/package.json
+++ b/packages/api-utility/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "devDependencies": {
     "rimraf": "^2.6.1",
-    "typescript": "^2.3.2"
+    "typescript": "^2.4.1"
   },
   "dependencies": {
     "containerjs-api-specification": "^0.0.3"


### PR DESCRIPTION
Change `postMessage` behaviour to emit `event` object containing `data` property, which matches native browser spec.
Browser no longer wraps `message` event (previously listener was being called twice - once with `event.data` and once with `data`).
Added a test for postMessage/emit behaviour