### PR TITLE
Introduce unit-testing of api-utility project

### DIFF
--- a/packages/api-utility/package.json
+++ b/packages/api-utility/package.json
@@ -19,11 +19,20 @@
     "clean": "rimraf build",
     "build": "npm run clean && npm run build:cjs && npm run build:es",
     "build:es": "rimraf build/es && tsc -p tsconfig.json -m ES2015 --outdir ./build/es",
-    "build:cjs": "rimraf build/lib && tsc -p tsconfig.json -m CommonJS --outdir ./build/lib"
+    "build:cjs": "rimraf build/lib && tsc -p tsconfig.json -m CommonJS --outdir ./build/lib",
+    "test": "ts-node --project test node_modules/tape/bin/tape node_modules/containerjs-api-specification/interface/*.ts test/**/*.test.ts | tap-diff"
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "devDependencies": {
+    "@types/proxyquire": "^1.3.27",
+    "@types/sinon": "^2.3.2",
+    "@types/tape": "^4.2.30",
+    "proxyquire": "^1.8.0",
     "rimraf": "^2.6.1",
+    "sinon": "^2.3.8",
+    "tap-diff": "^0.1.1",
+    "tape": "^4.7.0",
+    "ts-node": "^3.2.0",
     "typescript": "^2.4.1"
   },
   "dependencies": {

--- a/packages/api-utility/test/globals.ts
+++ b/packages/api-utility/test/globals.ts
@@ -1,0 +1,12 @@
+export const stubGlobal = (name: string, object: any) => {
+  const g: any = global;
+  g[name] = object;
+};
+
+export const globals = (api: any) => {
+  for (const name in api) {
+    if (api.hasOwnProperty(name)) {
+      stubGlobal(name, api[name]);
+    }
+  }
+};

--- a/packages/api-utility/test/tsconfig.json
+++ b/packages/api-utility/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "moduleResolution": "node",
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es2015",
+            "dom.iterable"
+        ],
+        "target": "es5",
+        "declaration": true
+    }
+}

--- a/packages/api-utility/test/uri.test.ts
+++ b/packages/api-utility/test/uri.test.ts
@@ -1,0 +1,35 @@
+import * as test from 'tape';
+import { globals } from './globals';
+import { Uri } from '../src/uri';
+
+const location = {
+    origin: 'http://test-site',
+    href: 'http://test-site/path/index.html'
+};
+
+test('Uri getAbsoluteUrl with absolute path expect same path', (t) => {
+    globals({ location });
+
+    const result = Uri.getAbsoluteUrl('http://other-site/other-path/image.jpg');
+
+    t.equal(result, 'http://other-site/other-path/image.jpg');
+    t.end();
+});
+
+test('Uri getAbsoluteUrl with relative to root path expect absolute path', (t) => {
+    globals({ location });
+
+    const result = Uri.getAbsoluteUrl('/other-path/image.jpg');
+
+    t.equal(result, 'http://test-site/other-path/image.jpg');
+    t.end();
+});
+
+test('Uri getAbsoluteUrl with relative to current path expect absolute path', (t) => {
+    globals({ location });
+
+    const result = Uri.getAbsoluteUrl('image.jpg');
+
+    t.equal(result, 'http://test-site/path/image.jpg');
+    t.end();
+});


### PR DESCRIPTION
Used `tape` for simple config, no need for browser
Added ability to set mock globals like `location` or `ssf`

I've added `sinon` for more sophisticated mocking and `proxyquire` to enable mocking of `require`/`import` dependencies, but not needed to use them yet for the simple initial tests