### PR TITLE
Hide not run browser tests from docs

### DIFF
--- a/packages/api-tests/generate-test-report.js
+++ b/packages/api-tests/generate-test-report.js
@@ -113,12 +113,17 @@ sortedTags.forEach((tag) => {
     openfin: {
       passed: openfinPassed,
       total
-    },
-    browser: {
-      passed: browserPassed,
-      total
     }
   };
+
+  // The browser doesn't implement all the methods that openfin and electron do.
+  // Only add the browser results if we actually have run any tests.
+  if (testTable.browser[tag]) {
+    outputJson[label].browser = {
+      passed: browserPassed,
+      total
+    };
+  }
 });
 
 const ghPagesMarkdown =


### PR DESCRIPTION
Tests that are not run for the browser are included in the documentation
for a method, showing as 0/x. This change is to only include tests for
the browser when we have actually run some tests.

Linked to #272 