### PR TITLE
Bump version numbers

### DIFF
--- a/packages/api-browser/package.json
+++ b/packages/api-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-browser",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "The ContainerJS browser API",
   "main": "build/dist/containerjs-api.js",
   "scripts": {
@@ -21,8 +21,8 @@
     "html2canvas": "^0.5.0-beta4"
   },
   "devDependencies": {
-    "containerjs-api-specification": "^0.0.3",
-    "containerjs-api-utility": "0.0.1",
+    "containerjs-api-specification": "^0.0.4",
+    "containerjs-api-utility": "^0.0.2",
     "copyfiles": "^1.2.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.6",

--- a/packages/api-demo/package.json
+++ b/packages/api-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-demo",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A bundle of containerJS APIs",
   "main": "src/index.js",
   "private": true,
@@ -24,9 +24,9 @@
   },
   "homepage": "https://github.com/symphonyoss/ContainerJS#readme",
   "dependencies": {
-    "containerjs-api-browser": "^0.0.2",
-    "containerjs-api-electron": "^0.0.3",
-    "containerjs-api-openfin": "^0.0.3",
+    "containerjs-api-browser": "^0.0.3",
+    "containerjs-api-electron": "^0.0.4",
+    "containerjs-api-openfin": "^0.0.4",
     "openfin-cli": "^1.1.5",
     "openfin-launcher": "^1.3.12"
   },

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-electron",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The ContainerJS Electron API",
   "main": "build/es/preload.js",
   "scripts": {
@@ -20,9 +20,9 @@
   "dependencies": {
     "@types/electron": "1.4.37",
     "@types/electron-notify": "^0.1.3",
-    "containerjs-api-specification": "^0.0.3",
+    "containerjs-api-specification": "^0.0.4",
+    "containerjs-api-utility": "^0.0.2",
     "electron": "1.6.6",
-    "containerjs-api-utility": "0.0.1",
     "electron-notify": "^0.1.0"
   },
   "bin": {

--- a/packages/api-openfin/package.json
+++ b/packages/api-openfin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-openfin",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The ContainerJS OpenFin API",
   "main": "build/lib/index.js",
   "module": "build/es/index.js",
@@ -21,8 +21,8 @@
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "devDependencies": {
-    "containerjs-api-specification": "^0.0.3",
-    "containerjs-api-utility": "0.0.1",
+    "containerjs-api-specification": "^0.0.4",
+    "containerjs-api-utility": "^0.0.2",
     "copyfiles": "^1.2.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.6",

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-specification",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The interface for the ContainerJS API",
   "scripts": {
     "typedoc2html": "node transform-type-info.js --testfile test-report.json --outfile ../../docs/Docs.html",

--- a/packages/api-symphony-compatibility/package.json
+++ b/packages/api-symphony-compatibility/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-compatibility",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A compatibility layer between symphony electron and ContainerJS",
   "main": "build/es/index.js",
   "scripts": {
@@ -25,10 +25,10 @@
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
-    "containerjs-api-browser": "^0.0.2",
-    "containerjs-api-electron": "^0.0.3",
-    "containerjs-api-openfin": "^0.0.3",
-    "containerjs-api-specification": "^0.0.3",
+    "containerjs-api-browser": "^0.0.3",
+    "containerjs-api-electron": "^0.0.4",
+    "containerjs-api-openfin": "^0.0.4",
+    "containerjs-api-specification": "^0.0.4",
     "openfin-cli": "^1.1.5",
     "openfin-launcher": "^1.3.12"
   },

--- a/packages/api-tests/package.json
+++ b/packages/api-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-tests",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "Apache-2.0",
   "main": "index.js",
   "private": true,
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "assert": "^1.4.1",
-    "containerjs-api-electron": "^0.0.3",
-    "containerjs-api-openfin": "^0.0.3",
-    "containerjs-api-browser": "^0.0.2",
+    "containerjs-api-browser": "^0.0.3",
+    "containerjs-api-electron": "^0.0.4",
+    "containerjs-api-openfin": "^0.0.4",
     "electron": "1.6.6",
     "live-server": "^1.2.0",
     "mocha": "^3.2.0",

--- a/packages/api-utility/package.json
+++ b/packages/api-utility/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerjs-api-utility",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Utility classes and functions for ContainerJS",
   "main": "build/es/index.js",
   "typings": "build/es/index",
@@ -32,6 +32,6 @@
     "typescript": "^2.4.1"
   },
   "dependencies": {
-    "containerjs-api-specification": "^0.0.3"
+    "containerjs-api-specification": "^0.0.4"
   }
 }


### PR DESCRIPTION
Something odd happened with the git tags, so they were deleted and readded. Will push the tags once this is merged.
 
- containerjs-api-browser@0.0.3
 - containerjs-api-demo@0.0.3
 - containerjs-api-electron@0.0.4
 - containerjs-api-openfin@0.0.4
 - containerjs-api-specification@0.0.4
 - containerjs-api-compatibility@0.0.3
 - containerjs-api-tests@0.0.3
 - containerjs-api-utility@0.0.2