### PR TITLE
Can send message to "*" (all windows) in OpenFin and Electron

### DIFF
--- a/packages/api-openfin/src/message-service.ts
+++ b/packages/api-openfin/src/message-service.ts
@@ -1,3 +1,5 @@
+const listenerMap = new Map();
+
 export class MessageService implements ssf.MessageService {
   // Window ID should be in the form 'application-uuid:window-name'
   static send(windowId: string, topic: string, message: any) {
@@ -11,22 +13,53 @@ export class MessageService implements ssf.MessageService {
   }
 
   static subscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
+    const thisWindowId = fin.desktop.Window.getCurrent().uuid;
+    const receiveMessage = (message, senderId) => {
+      // Don't send to self
+      if (senderId !== thisWindowId) {
+        listener(message, senderId);
+      }
+    };
+
+    // Map the arguments to the actual listener that was added
+    listenerMap.set({
+      windowId,
+      topic,
+      listener
+    }, receiveMessage);
+
     const [appId, windowName] = windowId.split(':');
 
     if (appId && windowName) {
-      fin.desktop.InterApplicationBus.subscribe(appId, windowName, topic, listener);
+      fin.desktop.InterApplicationBus.subscribe(appId, windowName, topic, receiveMessage);
     } else if (appId) {
-      fin.desktop.InterApplicationBus.subscribe(appId, topic, listener);
+      fin.desktop.InterApplicationBus.subscribe(appId, topic, receiveMessage);
     }
   }
 
   static unsubscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
-    const [appId, windowName] = windowId.split(':');
+    let deleteKey = null;
+    let receiveMessage = null;
 
-    if (appId && windowName) {
-      fin.desktop.InterApplicationBus.unsubscribe(appId, windowName, topic, listener);
-    } else if (appId) {
-      fin.desktop.InterApplicationBus.unsubscribe(appId, topic, listener);
+    // We cant use listenerMap.has() here because reconstructing the key from the arguments is a different object
+    // I.e. {} !== {}
+    listenerMap.forEach((value, key) => {
+      if (key.windowId === windowId && key.topic === topic && key.listener === listener) {
+        receiveMessage = value;
+        deleteKey = key;
+      }
+    });
+
+    if (deleteKey) {
+      listenerMap.delete(deleteKey);
+
+      const [appId, windowName] = windowId.split(':');
+
+      if (appId && windowName) {
+        fin.desktop.InterApplicationBus.unsubscribe(appId, windowName, topic, receiveMessage);
+      } else if (appId) {
+        fin.desktop.InterApplicationBus.unsubscribe(appId, topic, receiveMessage);
+      }
     }
   }
 }

--- a/packages/api-tests/test/messaging.spec.js
+++ b/packages/api-tests/test/messaging.spec.js
@@ -46,7 +46,7 @@ if (process.env.MOCHA_CONTAINER !== 'browser') {
     const unsubscribeScript = (id, topic, callback) => {
       ssf.MessageService.unsubscribe(id, topic, window.messageServiceFunction);
       callback();
-    }
+    };
     const sendMessageScript = (id, topic, message, callback) => {
       ssf.MessageService.send(id, topic, message);
       callback();
@@ -247,7 +247,7 @@ if (process.env.MOCHA_CONTAINER !== 'browser') {
 
       it('Should not receive message after unsubscribe #ssf.MessageService.unsubscribe', function() {
         const message = 'message';
-        
+
         const steps = [
           () => openNewWindow(app.client, defaultWindowOptions),
           () => selectWindow(app.client, 1),


### PR DESCRIPTION
Browser implementation coming next
Electron needs to send the message out to all Exectron windows if windowId is *
OpenFin implemented "*" already but didn't exclude receiving the message in the same window