### PR TITLE
Implemented message routing in browser

### DIFF
--- a/packages/api-browser/src/accessible-windows.ts
+++ b/packages/api-browser/src/accessible-windows.ts
@@ -1,12 +1,19 @@
 const accessibleWindows: Map<string, Window> = new Map();
 
-// If we have an opener, we are not the parent so we need to add it as a window
-if (window.opener) {
-  // The reference to the opener is not the full window object, so there is no onclose handler available
-  accessibleWindows['parent'] = window.opener;
-} else {
-  window.name = 'parent';
-}
+export const initialise = () => {
+  // If we have an opener, we are not the parent so we need to add it as a window
+  if (window.opener) {
+    // The reference to the opener is not the full window object, so there is no onclose handler available
+    accessibleWindows['parent'] = window.opener;
+  } else {
+    window.name = 'parent';
+  }
+
+  window.addEventListener('message', event => {
+    // Redistribute message up/down the tree
+    distributeMessage(event.data);
+  }, false);
+};
 
 export const getAccessibleWindows = () => accessibleWindows;
 export const getAccessibleWindow = (name: string) => accessibleWindows[name];
@@ -17,4 +24,29 @@ export const addAccessibleWindow = (name: string, win: Window) => {
 
 export const removeAccessibleWindow = (name: string) => {
   delete accessibleWindows[name];
+};
+
+interface MessageDetails {
+  senderId: string;
+  windowId: string; // May be wildcard "*"
+  topic: string;
+  message: any;
+  receivedFromId?: string;
+}
+
+export const distributeMessage = (messageDetails: MessageDetails): void => {
+  // Using receivedFromId avoids sending it back the way it came
+  const packet = Object.assign({}, messageDetails, {
+    receivedFromId: window.name
+  });
+
+  const windows = getAccessibleWindows();
+  for (const name in windows) {
+    if (windows.hasOwnProperty(name)
+        && name !== messageDetails.receivedFromId
+        && name !== messageDetails.senderId) {
+      const win = windows[name];
+      win.postMessage(packet, '*');
+    }
+  }
 };

--- a/packages/api-browser/src/app.ts
+++ b/packages/api-browser/src/app.ts
@@ -1,5 +1,12 @@
+import { initialise as initialiseWindows } from './accessible-windows';
+
+let initialised = false;
 export class app {
   static ready() {
+    if (!initialised) {
+      initialised = true;
+      initialiseWindows();
+    }
     return Promise.resolve();
   }
 

--- a/packages/api-browser/src/message-service.ts
+++ b/packages/api-browser/src/message-service.ts
@@ -1,24 +1,31 @@
-import { Window } from './window';
-import { getAccessibleWindow } from './accessible-windows';
+import { distributeMessage } from './accessible-windows';
 
 const listenerMap = new Map();
 
+const currentWindowId = (): string => {
+  return ssf.Window.getCurrentWindow().getId();
+};
+
 export class MessageService implements ssf.MessageService {
   static send(windowId: string, topic: string, message: any) {
-    const win = getAccessibleWindow(windowId);
-    const senderId = Window.getCurrentWindow().getId();
-    if (win) {
-      win.postMessage({
-        senderId,
-        topic,
-        message
-      }, '*');
-    }
+    const senderId = currentWindowId();
+
+    distributeMessage({
+      senderId,
+      windowId,
+      topic,
+      message
+    });
   }
 
   static subscribe(windowId: string, topic: string, listener: (...args: any[]) => void) {
     const receiveMessage = (event) => {
-      if ((windowId === '*' || windowId === event.data.senderId) && topic === event.data.topic) {
+      const thisId = currentWindowId();
+      if ((windowId === '*' || windowId === event.data.senderId)
+          && (event.data.windowId === '*' || thisId === event.data.windowId)
+          && event.data.senderId !== thisId
+          && topic === event.data.topic) {
+        // Message intended for this window
         listener(event.data.message, event.data.senderId);
       }
     };
@@ -40,7 +47,7 @@ export class MessageService implements ssf.MessageService {
     // I.e. {} !== {}
     listenerMap.forEach((value, key) => {
       if (key.windowId === windowId && key.topic === topic && key.listener === listener) {
-        window.removeEventListener('message', listener);
+        window.removeEventListener('message', value);
         deleteKey = key;
       }
     });

--- a/packages/api-openfin/src/app.ts
+++ b/packages/api-openfin/src/app.ts
@@ -1,10 +1,14 @@
 import { createMainProcess } from './main-process';
 
+let initialisePromise = null;
 export class app implements ssf.App {
   static ready() {
-    return new Promise<void>((resolve) => {
-      fin.desktop.main(() => createMainProcess(resolve));
-    });
+    if (!initialisePromise) {
+      initialisePromise = new Promise<void>((resolve) => {
+        fin.desktop.main(() => createMainProcess(resolve));
+      });
+    }
+    return initialisePromise;
   }
 
   static setBadgeCount(count: number) {

--- a/packages/api-tests/test/messaging.spec.js
+++ b/packages/api-tests/test/messaging.spec.js
@@ -19,250 +19,281 @@ const defaultWindowOptions = {
 
 let secondWindowId = '';
 
-if (process.env.MOCHA_CONTAINER !== 'browser') {
-  describe('Messaging API', function(done) {
-    const timeout = 90000;
-    this.timeout(timeout);
+describe('Messaging API', function(done) {
+  const timeout = 90000;
+  this.timeout(timeout);
 
-    beforeEach(() => {
-      app = setup(timeout);
+  beforeEach(() => {
+    app = setup(timeout);
 
-      return app.start();
-    });
+    return app.start();
+  });
 
-    afterEach(() => {
-      if (app && app.isRunning()) {
-        return app.stop();
-      }
-    });
+  afterEach(() => {
+    if (app && app.isRunning()) {
+      return app.stop();
+    }
+  });
 
-    const subscribeScript = (id, topic, callback) => {
-      window.messageServiceFunction = (message) => {
-        window.testMessage = message;
-      };
+  const subscribeScript = (id, topic, callback) => {
+    window.messageServiceFunction = (message) => {
+      window.testMessage = message;
+    };
+    ssf.app.ready().then(() => {
       ssf.MessageService.subscribe(id, topic, window.messageServiceFunction);
       callback(ssf.Window.getCurrentWindow().getId());
-    };
-    const unsubscribeScript = (id, topic, callback) => {
-      ssf.MessageService.unsubscribe(id, topic, window.messageServiceFunction);
-      callback();
-    };
-    const sendMessageScript = (id, topic, message, callback) => {
-      ssf.MessageService.send(id, topic, message);
-      callback();
-    };
-    const getMessageScript = (callback) => {
-      callback(window.testMessage);
-    };
+    });
+  };
+  const unsubscribeScript = (id, topic, callback) => {
+    ssf.MessageService.unsubscribe(id, topic, window.messageServiceFunction);
+    callback();
+  };
+  const sendMessageScript = (id, topic, message, callback) => {
+    ssf.MessageService.send(id, topic, message);
+    callback();
+  };
+  const getMessageScript = (callback) => {
+    callback(window.testMessage);
+  };
 
-    it('Should have ssf.MessageService available globally', () => {
-      const script = (callback) => {
-        ssf.app.ready().then(() => {
-          if (ssf.MessageService !== undefined) {
-            callback();
-          }
-        });
+  it('Should have ssf.MessageService available globally', () => {
+    const script = (callback) => {
+      ssf.app.ready().then(() => {
+        if (ssf.MessageService !== undefined) {
+          callback();
+        }
+      });
+    };
+    return executeAsyncJavascript(app.client, script);
+  });
+
+  describe('Send message', () => {
+    it('Should send string correctly #ssf.MessageService.send', function() {
+      const message = 'message';
+
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        (result) => { secondWindowId = result.value; },
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, message)
+      ];
+
+      return chainPromises(steps);
+    });
+
+    it('Should send javascript object correctly #ssf.MessageService.send', function() {
+      const message = {
+        a: 1,
+        b: '20'
       };
-      return executeAsyncJavascript(app.client, script);
+
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        (result) => { secondWindowId = result.value; },
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.deepStrictEqual(result.value, message)
+      ];
+
+      return chainPromises(steps);
     });
 
-    describe('Send message', () => {
-      it('Should send string correctly #ssf.MessageService.send', function() {
-        const message = 'message';
+    it('Should send message with windowId to the correct window #ssf.MessageService.send', function() {
+      const message = 'message';
 
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          (result) => { secondWindowId = result.value; },
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, message)
-        ];
+      const thirdWindowOptions = {
+        url: 'http://localhost:5000/index.html',
+        name: 'messagetest2',
+        show: true,
+        child: true
+      };
 
-        return chainPromises(steps);
-      });
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => openNewWindow(app.client, thirdWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        (result) => { secondWindowId = result.value; },
+        () => selectWindow(app.client, 2),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, message),
+        () => selectWindow(app.client, 2),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, undefined)
+      ];
 
-      it('Should send javascript object correctly #ssf.MessageService.send', function() {
-        const message = {
-          a: 1,
-          b: '20'
-        };
-
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          (result) => { secondWindowId = result.value; },
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.deepStrictEqual(result.value, message)
-        ];
-
-        return chainPromises(steps);
-      });
-
-      it('Should send message with windowId to the correct window #ssf.MessageService.send', function() {
-        const message = 'message';
-
-        const thirdWindowOptions = {
-          url: 'http://localhost:5000/index.html',
-          name: 'messagetest2',
-          show: true,
-          child: true
-        };
-
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => openNewWindow(app.client, thirdWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          (result) => { secondWindowId = result.value; },
-          () => selectWindow(app.client, 2),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, message),
-          () => selectWindow(app.client, 2),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, undefined)
-        ];
-
-        return chainPromises(steps);
-      });
-
-      it('Should send message with wildcard to all windows excluding self #ssf.MessageService.send', function() {
-        const message = 'message';
-
-        const thirdWindowOptions = {
-          url: 'http://localhost:5000/index.html',
-          name: 'messagetest2',
-          show: true,
-          child: true
-        };
-
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => openNewWindow(app.client, thirdWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          () => selectWindow(app.client, 2),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          () => executeAsyncJavascript(app.client, sendMessageScript, '*', 'topic', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, message),
-          () => selectWindow(app.client, 2),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, message),
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, undefined)
-        ];
-
-        return chainPromises(steps);
-      });
+      return chainPromises(steps);
     });
 
-    describe('Receive message', () => {
-      it('Should call listener when subscribed to correct topic #ssf.MessageService.subscribe', function() {
-        const message = 'message';
+    it('Should send message with wildcard to all windows excluding self #ssf.MessageService.send', function() {
+      const message = 'message';
 
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          (result) => { secondWindowId = result.value; },
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, message)
-        ];
+      const thirdWindowOptions = {
+        url: 'http://localhost:5000/index.html',
+        name: 'messagetest2',
+        show: true,
+        child: true
+      };
 
-        return chainPromises(steps);
-      });
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => openNewWindow(app.client, thirdWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        () => selectWindow(app.client, 2),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        () => executeAsyncJavascript(app.client, sendMessageScript, '*', 'topic', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, message),
+        () => selectWindow(app.client, 2),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, message),
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, undefined)
+      ];
 
-      it('Should not call listener when subscribed to wildcard topic #ssf.MessageService.subscribe', function() {
-        const message = 'message';
+      return chainPromises(steps);
+    });
 
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', '*'),
-          (result) => { secondWindowId = result.value; },
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, undefined)
-        ];
+    it('Should send message to sibling window #ssf.MessageService.send', function() {
+      const message = 'message';
 
-        return chainPromises(steps);
-      });
+      const thirdWindowOptions = {
+        url: 'http://localhost:5000/index.html',
+        name: 'messagetest2',
+        show: true,
+        child: true
+      };
+      let thirdWindowId;
 
-      it('Should not receive message from wrong topic listener #ssf.MessageService.subscribe', function() {
-        const message = 'message';
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => openNewWindow(app.client, thirdWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        () => selectWindow(app.client, 2),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        (result) => { thirdWindowId = result.value; },
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, sendMessageScript, thirdWindowId, 'topic', message),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, undefined),
+        () => selectWindow(app.client, 2),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, message)
+      ];
 
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          (result) => { secondWindowId = result.value; },
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic2', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, undefined)
-        ];
-
-        return chainPromises(steps);
-      });
-
-      it('Should not receive message from wrong id #ssf.MessageService.subscribe', function() {
-        const message = 'message';
-
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, 'wrong', 'topic'),
-          (result) => { secondWindowId = result.value; },
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, undefined)
-        ];
-
-        return chainPromises(steps);
-      });
-
-      it('Should not receive message after unsubscribe #ssf.MessageService.unsubscribe', function() {
-        const message = 'message';
-
-        const steps = [
-          () => openNewWindow(app.client, defaultWindowOptions),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
-          (result) => { secondWindowId = result.value; },
-          () => executeAsyncJavascript(app.client, unsubscribeScript, '*', 'topic'),
-          () => selectWindow(app.client, 0),
-          () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
-          () => selectWindow(app.client, 1),
-          () => executeAsyncJavascript(app.client, getMessageScript),
-          (result) => assert.equal(result.value, undefined)
-        ];
-
-        return chainPromises(steps);
-      });
+      return chainPromises(steps);
     });
   });
-}
+
+  describe('Receive message', () => {
+    it('Should call listener when subscribed to correct topic #ssf.MessageService.subscribe', function() {
+      const message = 'message';
+
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        (result) => { secondWindowId = result.value; },
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, message)
+      ];
+
+      return chainPromises(steps);
+    });
+
+    it('Should not call listener when subscribed to wildcard topic #ssf.MessageService.subscribe', function() {
+      const message = 'message';
+
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', '*'),
+        (result) => { secondWindowId = result.value; },
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, undefined)
+      ];
+
+      return chainPromises(steps);
+    });
+
+    it('Should not receive message from wrong topic listener #ssf.MessageService.subscribe', function() {
+      const message = 'message';
+
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        (result) => { secondWindowId = result.value; },
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic2', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, undefined)
+      ];
+
+      return chainPromises(steps);
+    });
+
+    it('Should not receive message from wrong id #ssf.MessageService.subscribe', function() {
+      const message = 'message';
+
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, 'wrong', 'topic'),
+        (result) => { secondWindowId = result.value; },
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, undefined)
+      ];
+
+      return chainPromises(steps);
+    });
+
+    it('Should not receive message after unsubscribe #ssf.MessageService.unsubscribe', function() {
+      const message = 'message';
+
+      const steps = [
+        () => openNewWindow(app.client, defaultWindowOptions),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, subscribeScript, '*', 'topic'),
+        (result) => { secondWindowId = result.value; },
+        () => executeAsyncJavascript(app.client, unsubscribeScript, '*', 'topic'),
+        () => selectWindow(app.client, 0),
+        () => executeAsyncJavascript(app.client, sendMessageScript, secondWindowId, 'topic', message),
+        () => selectWindow(app.client, 1),
+        () => executeAsyncJavascript(app.client, getMessageScript),
+        (result) => assert.equal(result.value, undefined)
+      ];
+
+      return chainPromises(steps);
+    });
+  });
+});


### PR DESCRIPTION
All windows pass all messages received to parent and all child windows, unless the message is one they sent or have already forwarded. This allows communication between grand-child windows and siblings etc.

Guard OpenFin `app.ready` so that the initialisation doesn't get re-run.