### PR TITLE
Added resize event to browser container

### DIFF
--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -214,5 +214,6 @@ const eventMap = {
   'focus': 'focus',
   'hide': 'hidden',
   'message': 'message',
-  'show': 'load'
+  'show': 'load',
+  'resize': 'resize'
 };


### PR DESCRIPTION
This is used by the symphony shim demo.
It also uses the move event, but browser won't support that.