### PR TITLE
Option to bundle symphony shim with containerjs in all containers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ $ npm install --global containerjs-api-electron
 From within your 'Hello World' folder, execute the following:
 
 ```
-$ ssf-electron app.json
+$ ssf-electron --config app.json
 ```
 
 You should now see exactly the same app running within Electron.

--- a/packages/api-browser/package.json
+++ b/packages/api-browser/package.json
@@ -5,7 +5,8 @@
   "main": "build/dist/containerjs-api.js",
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && tsc && rollup -c"
+    "build": "npm run clean && tsc && rollup -c && npm run bundle",
+    "bundle": "concat -o build/dist/containerjs-api-symphony.js build/dist/containerjs-api.js node_modules/containerjs-api-compatibility/build/dist/containerjs-api-compatibility.js"
   },
   "repository": {
     "type": "git",
@@ -21,6 +22,8 @@
     "html2canvas": "^0.5.0-beta4"
   },
   "devDependencies": {
+    "concat": "^1.0.3",
+    "containerjs-api-compatibility": "^0.0.3",
     "containerjs-api-specification": "^0.0.4",
     "containerjs-api-utility": "^0.0.2",
     "copyfiles": "^1.2.0",

--- a/packages/api-demo/package.json
+++ b/packages/api-demo/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "serve:no-browser": "npm run serve -- --no-browser",
     "serve": "live-server --mount=/:src --mount=/scripts/containerjs-api:node_modules/containerjs-api-browser/build/dist/containerjs-api.js --mount=/resources/notification.html:node_modules/containerjs-api-openfin/build/dist/notification.html",
-    "launch:electron": "ssf-electron ./src/app.json",
+    "launch:electron": "ssf-electron -c ./src/app.json",
     "electron": "npm-run-all --parallel launch:electron serve:no-browser",
     "launch:openfin": "ssf-openfin -c ./src/app.json",
     "openfin": "npm-run-all --parallel launch:openfin serve:no-browser",

--- a/packages/api-electron/README.md
+++ b/packages/api-electron/README.md
@@ -45,5 +45,5 @@ npm install --global containerjs-api-electron
 To run the application, do:
 
 ```
-ssf-electron ./path/to/app.json
+ssf-electron -c ./path/to/app.json
 ```

--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -9,9 +9,11 @@ const { IpcMessages } = require('./src/common/constants');
 
 let win;
 const windows = [];
-const preloadPath = path.join(__dirname, 'build', 'dist', 'containerjs-api.js');
 
-module.exports = (appJson) => {
+module.exports = (appJson, useSymphony) => {
+  const preloadFile = useSymphony ? 'containerjs-api-symphony.js' : 'containerjs-api.js';
+  const preloadPath = path.join(__dirname, 'build', 'dist', preloadFile);
+
   ipc.on(IpcMessages.IPC_SSF_NEW_WINDOW, (e, msg) => {
     const options = Object.assign(
       {},
@@ -68,10 +70,10 @@ module.exports = (appJson) => {
     }
   });
 
-  createInitialHiddenWindow(appJson);
+  createInitialHiddenWindow(appJson, preloadPath);
 };
 
-const createInitialHiddenWindow = (appJson) => {
+const createInitialHiddenWindow = (appJson, preloadPath) => {
   // Create an invisible window to run the load script
   win = new BrowserWindow({
     width: 800,

--- a/packages/api-electron/main.js
+++ b/packages/api-electron/main.js
@@ -1,6 +1,12 @@
 const { app } = require('electron');
 const ssfElectron = require('./index.js');
 const fs = require('fs');
+const program = require('commander');
+
+program
+  .option('-c, --config [filename]', 'ContainerJS config file', 'app.json')
+  .option('-s, --symphony', '(Optional) Use Symphony compatibility layer', (v, val) => true, false)
+  .parse(process.argv);
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -8,11 +14,11 @@ let win;
 
 function createWindow() {
   // the appJson location is passed to the ssf-electron bin script
-  const configLocation = process.argv[5];
+  const configLocation = program.config;
   const appJsonPath = process.cwd() + '/' + configLocation;
   const appJson = JSON.parse(fs.readFileSync(appJsonPath, 'utf8'));
 
-  ssfElectron(appJson);
+  ssfElectron(appJson, program.symphony);
 }
 
 ssfElectron.app.ready(createWindow);

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -5,7 +5,8 @@
   "main": "build/es/preload.js",
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && tsc && rollup -c"
+    "build": "npm run clean && tsc && rollup -c && npm run bundle",
+    "bundle": "concat -o build/dist/containerjs-api-symphony.js build/dist/containerjs-api.js node_modules/containerjs-api-compatibility/build/dist/containerjs-api-compatibility.js"
   },
   "repository": {
     "type": "git",
@@ -20,6 +21,8 @@
   "dependencies": {
     "@types/electron": "1.4.37",
     "@types/electron-notify": "0.1.3",
+    "commander": "^2.11.0",
+    "containerjs-api-compatibility": "^0.0.3",
     "containerjs-api-specification": "^0.0.4",
     "containerjs-api-utility": "^0.0.2",
     "electron": "1.6.6",
@@ -29,6 +32,7 @@
     "ssf-electron": "./bin/ssf-electron"
   },
   "devDependencies": {
+    "concat": "^1.0.3",
     "copyfiles": "^1.2.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.6",

--- a/packages/api-openfin/bin/ssf-openfin
+++ b/packages/api-openfin/bin/ssf-openfin
@@ -11,11 +11,13 @@ program
   .option('-v, --version [version]', 'Version of the OpenFin runtime to use, default is stable', 'stable')
   .option('-u, --url [url]', '(Optional) Url to read the new app.json file from to start OpenFin')
   .option('-n, --notification [directory]', '(Optional) Generate an example notification file in the specified directory')
+  .option('-s, --symphony', '(Optional) Use Symphony compatibility layer', (v, val) => true, false)
   .parse(process.argv);
 
 const openfinConfigFile = path.join(process.cwd(), program.outputConfig);
 const configFile = path.join(process.cwd(), program.config);
-const preloadFile = path.join(__dirname, '../build/dist/containerjs-api.js');
+const preloadFile = program.symphony ? 'containerjs-api-symphony.js' : 'containerjs-api.js';
+const preloadPath = path.join(__dirname, `../build/dist/${preloadFile}`);
 const notificationFile = path.join(__dirname, '../build/dist/notification.html');
 
 const fileError = (filename, err) => {
@@ -34,7 +36,7 @@ const openfinConfig = {
 
 if (fs.existsSync(configFile)) {
   const parsedConfig = JSON.parse(fs.readFileSync(configFile));
-  parsedConfig.preload = preloadFile;
+  parsedConfig.preload = preloadPath;
   openfinConfig.startup_app = parsedConfig;
   fs.writeFileSync(openfinConfigFile, JSON.stringify(openfinConfig));
   if (program.notification) {

--- a/packages/api-openfin/package.json
+++ b/packages/api-openfin/package.json
@@ -8,7 +8,8 @@
   "browser": "build/dist/containerjs-api.js",
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && tsc && rollup -c && copyfiles -f src/notification.html ./build/dist"
+    "build": "npm run clean && tsc && rollup -c && copyfiles -f src/notification.html ./build/dist && npm run bundle",
+    "bundle": "concat -o build/dist/containerjs-api-symphony.js build/dist/containerjs-api.js node_modules/containerjs-api-compatibility/build/dist/containerjs-api-compatibility.js"
   },
   "repository": {
     "type": "git",
@@ -21,6 +22,8 @@
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "devDependencies": {
+    "concat": "^1.0.3",
+    "containerjs-api-compatibility": "^0.0.3",
     "containerjs-api-specification": "^0.0.4",
     "containerjs-api-utility": "^0.0.2",
     "copyfiles": "^1.2.0",

--- a/packages/api-symphony-compatibility/index.ts
+++ b/packages/api-symphony-compatibility/index.ts
@@ -1,5 +1,10 @@
 import { map } from './src/mapping';
 
+const ssf = (window as any).ssf;
+const api = (ssf && ssf.registerBoundsChange)
+    ? ssf
+    : map.ssf;
+
 /* tslint:disable:no-default-export */
-export default map.ssf;
+export default api;
 /* tslint:enable:no-default-export */

--- a/packages/api-symphony-compatibility/package.json
+++ b/packages/api-symphony-compatibility/package.json
@@ -5,7 +5,7 @@
   "main": "build/es/index.js",
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && tsc && rollup -c && copyfiles -f src/notification.html ./build/dist"
+    "build": "npm run clean && tsc && rollup -c"
   },
   "repository": {
     "type": "git",

--- a/packages/api-symphony-demo/package.json
+++ b/packages/api-symphony-demo/package.json
@@ -4,10 +4,10 @@
   "description": "A demo project using the compatibility layer between ContainerJS and Symphony",
   "scripts": {
     "serve:no-browser": "npm run serve -- --no-browser",
-    "serve": "live-server --mount=/:src --mount=/scripts/containerjs-api:node_modules/containerjs-api-browser/build/dist/containerjs-api.js --mount=/scripts/containerjs-api-compatibility:node_modules/containerjs-api-compatibility/build/dist/containerjs-api-compatibility.js",
-    "launch:electron": "ssf-electron ./src/app.json",
+    "serve": "live-server --mount=/:src --mount=/scripts/containerjs-api-symphony:node_modules/containerjs-api-browser/build/dist/containerjs-api-symphony.js",
+    "launch:electron": "ssf-electron -c ./src/app.json --symphony",
     "electron": "npm-run-all --parallel launch:electron serve:no-browser",
-    "launch:openfin": "ssf-openfin -c ./src/app.json",
+    "launch:openfin": "ssf-openfin -c ./src/app.json --symphony",
     "openfin": "npm-run-all --parallel launch:openfin serve:no-browser",
     "browser": "npm run serve"
   },
@@ -24,8 +24,7 @@
   "dependencies": {
     "containerjs-api-browser": "^0.0.3",
     "containerjs-api-electron": "^0.0.4",
-    "containerjs-api-openfin": "^0.0.4",
-    "containerjs-api-compatibility": "^0.0.3"
+    "containerjs-api-openfin": "^0.0.4"
   },
   "devDependencies": {
     "live-server": "^1.2.0",

--- a/packages/api-symphony-demo/src/index.html
+++ b/packages/api-symphony-demo/src/index.html
@@ -41,8 +41,7 @@
   </form>
 </div>
 
-<script src="/scripts/containerjs-api"></script>
-<script src="/scripts/containerjs-api-compatibility"></script>
+<script src="/scripts/containerjs-api-symphony"></script>
 
 <script>
   const xPos = document.getElementById('xPos');


### PR DESCRIPTION
ssf-electron / ssf-openfin option `--symphony` to use symphony shim version

ssf-electron now uses `--config` option for config like ssf-openfin does

browser version builds both containerjs and symphony versions of api

api-symphony-compatibility loads as polyfill so we don't accidentally replace the preloaded symphony api with the browser version