### PR TITLE
Remove @types/electron and update

### DIFF
--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -19,12 +19,12 @@
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
-    "@types/electron-notify": "^0.1.3",
+    "@types/electron-notify": "^0.1.5",
     "commander": "^2.11.0",
     "containerjs-api-compatibility": "^0.0.6",
     "containerjs-api-specification": "^0.0.7",
     "containerjs-api-utility": "^0.0.5",
-    "electron": "^1.6.6",
+    "electron": "^1.7.5",
     "electron-notify": "^0.1.0",
     "node-fetch": "^1.7.3",
     "util.promisify": "^1.0.0"

--- a/packages/api-electron/package.json
+++ b/packages/api-electron/package.json
@@ -19,13 +19,12 @@
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
-    "@types/electron": "1.4.37",
-    "@types/electron-notify": "0.1.3",
+    "@types/electron-notify": "^0.1.3",
     "commander": "^2.11.0",
     "containerjs-api-compatibility": "^0.0.6",
     "containerjs-api-specification": "^0.0.7",
     "containerjs-api-utility": "^0.0.5",
-    "electron": "1.6.6",
+    "electron": "^1.6.6",
     "electron-notify": "^0.1.0",
     "node-fetch": "^1.7.3",
     "util.promisify": "^1.0.0"

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -253,11 +253,11 @@ export class Window extends Emitter implements ssf.Window {
   }
 
   innerAddEventListener(event: string, listener: (...args: any[]) => void) {
-    this.innerWindow.addListener(event, listener);
+    (this.innerWindow as NodeJS.EventEmitter).addListener(event, listener);
   }
 
   innerRemoveEventListener(event: string, listener: (...args: any[]) => void) {
-    this.innerWindow.removeListener(event, listener);
+    (this.innerWindow as NodeJS.EventEmitter).removeListener(event, listener);
   }
 
   postMessage(message: any) {

--- a/packages/api-specification/package.json
+++ b/packages/api-specification/package.json
@@ -18,10 +18,10 @@
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "dependencies": {
-    "@types/electron": "1.4.37",
     "@types/openfin": "^17.0.2",
     "commander": "^2.9.0",
     "copyfiles": "^1.2.0",
+    "electron": "^1.7.5",
     "gray-matter": "^2.1.1",
     "html2json": "^1.0.2",
     "json-transforms": "^1.1.2",

--- a/packages/api-utility/package.json
+++ b/packages/api-utility/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://symphonyoss.github.io/ContainerJS/",
   "devDependencies": {
+    "@types/node": "^8.0.32",
     "@types/proxyquire": "^1.3.27",
     "@types/sinon": "^2.3.2",
     "@types/tape": "^4.2.30",
@@ -28,7 +29,7 @@
     "rimraf": "^2.6.1",
     "sinon": "^2.3.8",
     "tap-diff": "^0.1.1",
-    "tape": "^4.7.0",
+    "tape": "^4.8.0",
     "typescript": "^2.4.1"
   },
   "dependencies": {


### PR DESCRIPTION
Remove @types/electron as a dependency, as it has been deprecated due to
electron shipping types alongside it's main npm package.

Update @types/notify-electron to use the latest version.

Resolves #304 and #191 .

Currently fails due to https://github.com/electron/electron/issues/9626.