### PR TITLE
Emit capture event when called on Window

### DIFF
--- a/packages/api-browser/src/window.ts
+++ b/packages/api-browser/src/window.ts
@@ -196,7 +196,10 @@ export class Window extends Emitter implements ssf.WindowCore {
 
   capture() {
     return html2canvas(this.innerWindow.document.documentElement)
-      .then((canvas) => canvas.toDataURL());
+      .then((canvas) => {
+        this.emit('capture');
+        return canvas.toDataURL();
+      });
   }
 }
 
@@ -223,5 +226,6 @@ const eventMap = {
   'hide': 'hidden',
   'message': 'message',
   'show': 'load',
-  'resize': 'resize'
+  'resize': 'resize',
+  'capture': 'capture'
 };

--- a/packages/api-demo/src/window/window-api-demo.js
+++ b/packages/api-demo/src/window/window-api-demo.js
@@ -63,6 +63,26 @@ appReady.then(() => {
       win.addListener('close', () => {
         addListItem('close');
       });
+
+      win.addListener('maximize', () => {
+        addListItem('maximize');
+      });
+
+      win.addListener('unmaximize', () => {
+        addListItem('unmaximize');
+      });
+
+      win.addListener('minimize', () => {
+        addListItem('minimize');
+      });
+
+      win.addListener('restore', () => {
+        addListItem('restore');
+      });
+
+      win.addListener('capture', () => {
+        addListItem('capture');
+      });
     });
   };
 

--- a/packages/api-electron/src/preload/window.ts
+++ b/packages/api-electron/src/preload/window.ts
@@ -312,6 +312,7 @@ export class Window extends Emitter implements ssf.Window {
     return new Promise<string>((resolve) => {
       this.innerWindow.capturePage((image: any) => {
         const dataUri = 'data:image/png;base64,' + image.toPng().toString('base64');
+        this.emit('capture');
         resolve(dataUri);
       });
     });

--- a/packages/api-openfin/src/window.ts
+++ b/packages/api-openfin/src/window.ts
@@ -30,7 +30,8 @@ const eventMap = {
   'navigation-rejected': 'navigation-rejected',
   'restore': 'restored',
   'show-requested': 'show-requested',
-  'show': 'shown'
+  'show': 'shown',
+  'capture': 'capture'
 };
 
 type WindowState = 'maximized' | 'minimized' | 'restored';
@@ -516,7 +517,10 @@ export class Window extends Emitter implements ssf.Window {
 
   capture() {
     return new Promise<string>((resolve, reject) => {
-      this.innerWindow.getSnapshot((snapshot) => { resolve('data:image/png;base64,' + snapshot); }, reject);
+      this.innerWindow.getSnapshot((snapshot) => {
+        this.emit('capture');
+        resolve('data:image/png;base64,' + snapshot);
+      }, reject);
     });
   }
 }

--- a/packages/api-tests/test/window.core.spec.js
+++ b/packages/api-tests/test/window.core.spec.js
@@ -823,6 +823,44 @@ describe('WindowCore API', function(done) {
 
       return chainPromises(steps);
     });
+
+    it('Should emit a "capture" event #ssf.WindowCore.capture', function() {
+      const windowTitle = 'windoweventshow';
+      const windowOptions = getWindowOptions({
+        name: windowTitle
+      });
+
+      const event = 'capture';
+
+      const addListener = (event) => {
+        const script = (event, callback) => {
+          const currentWindow = ssf.Window.getCurrentWindow();
+          currentWindow.addListener(event, () => { window.listenEventResult = true; });
+          callback();
+        };
+        return executeAsyncJavascript(app.client, script, event);
+      };
+
+      const retrieveListenerResult = () => {
+        const script = (callback) => {
+          callback(window.listenEventResult);
+        };
+        return executeAsyncJavascript(app.client, script);
+      };
+
+      const retrieveDelay = 500;
+
+      const steps = [
+        ...setupWindowSteps(windowOptions),
+        () => addListener(event),
+        () => callAsyncWindowMethod(event),
+        () => wait(retrieveDelay),
+        () => retrieveListenerResult(),
+        (result) => assert.equal(result.value, true)
+      ];
+
+      return chainPromises(steps);
+    });
   });
 
   describe('New Window', function() {


### PR DESCRIPTION
Add test for capture event being called on Window.

Ensure Window implementations emit the capture event when successful.

Resolves #301 