### PR TITLE
Add WindowOptions to docs

### DIFF
--- a/packages/api-specification/interface/openfin-extension.ts
+++ b/packages/api-specification/interface/openfin-extension.ts
@@ -1,5 +1,6 @@
 /**
  * @ignore
+ * @hidden
  */
 declare namespace fin {
   interface OpenFinWindow {

--- a/packages/api-specification/interface/window-extension.ts
+++ b/packages/api-specification/interface/window-extension.ts
@@ -7,6 +7,7 @@
 
 /**
  * @ignore
+ * @hidden
  */
 declare interface Screen {
   orientation: Orientation;
@@ -14,6 +15,7 @@ declare interface Screen {
 
 /**
  * @ignore
+ * @hidden
  */
 interface Orientation {
   angle: number;


### PR DESCRIPTION
Typedoc doesn't currently support @ignore - it uses @hidden. (See https://github.com/TypeStrong/typedoc/issues/198). Adding @hidden alongside the @ignore correctly supresses the fin.WindowOptions, which was generating invalid json (an array within an array for the child property), and correctly creates the WindowOptions documentation.

Fixes #312 