### PR TITLE
Rename the app interface from App to app

### DIFF
--- a/packages/api-browser/src/app.ts
+++ b/packages/api-browser/src/app.ts
@@ -1,7 +1,7 @@
 import { initialise as initialiseWindows } from './accessible-windows';
 
 let initialised = false;
-export class app {
+export class app implements ssf.app {
   static ready() {
     if (!initialised) {
       initialised = true;

--- a/packages/api-electron/src/preload/app.ts
+++ b/packages/api-electron/src/preload/app.ts
@@ -1,6 +1,6 @@
 const electronApp = require('electron').remote.app;
 
-export class app implements ssf.App {
+export class app implements ssf.app {
   static ready() {
     return Promise.resolve();
   }

--- a/packages/api-openfin/src/app.ts
+++ b/packages/api-openfin/src/app.ts
@@ -1,7 +1,7 @@
 import { createMainProcess } from './main-process';
 
 let initialisePromise = null;
-export class app implements ssf.App {
+export class app implements ssf.app {
   static ready() {
     if (!initialisePromise) {
       initialisePromise = new Promise<void>((resolve) => {

--- a/packages/api-specification/interface/app.ts
+++ b/packages/api-specification/interface/app.ts
@@ -1,5 +1,5 @@
 declare namespace ssf {
-  class App {
+  class app {
     /**
      * A promise that resolves when the API has finished bootstrapping.
      */


### PR DESCRIPTION
Rename the app interface from App to app.
Update usages.
Implement interface in browser app.

Resolves #311 