### PR TITLE
Mark packages private to prevent npm publishing

### DIFF
--- a/packages/api-symphony-demo/package.json
+++ b/packages/api-symphony-demo/package.json
@@ -2,6 +2,7 @@
   "name": "containerjs-api-symphony-demo",
   "version": "0.0.1",
   "description": "A demo project using the compatibility layer between ContainerJS and Symphony",
+  "private": true,
   "scripts": {
     "electron": "ssf-electron -c ./src/app.json --symphony",
     "openfin": "ssf-openfin -c ./src/app.json --symphony"

--- a/packages/api-utility/package.json
+++ b/packages/api-utility/package.json
@@ -2,6 +2,7 @@
   "name": "containerjs-api-utility",
   "version": "0.0.2",
   "description": "Utility classes and functions for ContainerJS",
+  "private": true,
   "main": "build/es/index.js",
   "typings": "build/es/index",
   "repository": {


### PR DESCRIPTION
Lerna will only publish those packages not marked as private. We do not
want to publish the symphony demo, nor continue to publish the utility
package, so mark them private.

Resolved #329 