### PR TITLE
Add -d command line switch for ssf-electron

### DIFF
--- a/packages/api-electron/index.js
+++ b/packages/api-electron/index.js
@@ -10,9 +10,15 @@ const { IpcMessages } = require('./src/common/constants');
 let win;
 const windows = [];
 
-module.exports = (appJson, useSymphony) => {
+module.exports = (appJson, useSymphony, showDeveloperMenu) => {
   const preloadFile = useSymphony ? 'containerjs-api-symphony.js' : 'containerjs-api.js';
   const preloadPath = path.join(__dirname, 'build', 'dist', preloadFile);
+
+  if (!showDeveloperMenu) {
+    app.on('browser-window-created', function(e, window) {
+      window.setMenu(null);
+    });
+  }
 
   ipc.on(IpcMessages.IPC_SSF_NEW_WINDOW, (e, msg) => {
     const options = Object.assign(

--- a/packages/api-electron/main.js
+++ b/packages/api-electron/main.js
@@ -6,6 +6,7 @@ const program = require('commander');
 program
   .option('-c, --config [filename]', 'ContainerJS config file', 'app.json')
   .option('-s, --symphony', '(Optional) Use Symphony compatibility layer', (v, val) => true, false)
+  .option('-d, --developer', '(Optional) Show developer menu', (v, val) => true, false)
   .parse(process.argv);
 
 // Keep a global reference of the window object, if you don't, the window will
@@ -18,7 +19,7 @@ function createWindow() {
   const appJsonPath = process.cwd() + '/' + configLocation;
   const appJson = JSON.parse(fs.readFileSync(appJsonPath, 'utf8'));
 
-  ssfElectron(appJson, program.symphony);
+  ssfElectron(appJson, program.symphony, program.developer);
 }
 
 ssfElectron.app.ready(createWindow);


### PR DESCRIPTION
Add -d/--developer command line switch for ssf-electron to control
whether the menu bar is shown or not. Default is to not show.

Resolves #319 