### PR TITLE
Docs explain that Window is not available in Browser

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -53,6 +53,10 @@ p {
   margin-bottom: 5px;
 }
 
+br {
+  line-height: 35px;
+}
+
 .lead {
   margin-top: 12px;
 }

--- a/packages/api-specification/interface/notification.ts
+++ b/packages/api-specification/interface/notification.ts
@@ -33,7 +33,8 @@ declare namespace ssf {
    * Creates a new Desktop Notification.
    *
    * Notifications are created via a constructor which takes a title and
-   * an options object with body text and additional view options
+   * an options object with body text and additional view options.
+   *
    * A Notification emits click events when the user clicks on it
    *
    * <pre>

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -137,6 +137,20 @@ declare namespace ssf {
     show: 'show';
   }
 
+  /**
+    * Creates and controls windows.
+    *
+    * <i>WindowCore is implemented in the Browser, which offers a subset of the
+    * features available in OpenFin and Electron. For OpenFin and Electron
+    * specific behaviour, see <a href="#Window">Window</a> instead.</i>
+    *
+    * Windows are created via a constructor which takes a configuration object
+    * that details the window's behaviour.
+    *
+    * <pre>
+    * const win = new Window({url: 'http://localhost/index.html'});
+    * </pre>
+    */
   export abstract class WindowCore extends ssf.EventEmitter {
     /**
      * The id that uniquely identifies the window
@@ -299,6 +313,10 @@ declare namespace ssf {
 
    /**
     * Creates and controls windows.
+    *
+    * <i>The full Window interface is only available in OpenFin and Electron.
+    * For Browser and features available in all platforms,
+    * use <a href="#WindowCore">WindowCore</a> instead.</i>
     *
     * Windows are created via a constructor which takes a configuration object
     * that details the window's behaviour.

--- a/packages/api-specification/interface/window.ts
+++ b/packages/api-specification/interface/window.ts
@@ -137,7 +137,7 @@ declare namespace ssf {
     show: 'show';
   }
 
-  /**
+   /**
     * Creates and controls windows.
     *
     * <i>WindowCore is implemented in the Browser, which offers a subset of the

--- a/packages/api-specification/transform-type-info.js
+++ b/packages/api-specification/transform-type-info.js
@@ -112,8 +112,10 @@ const formatType = (type) => {
   return 'UNKNOWN';
 };
 
+const breakText = (text) => text ? text.split(/\n\n/) : [];
 const formatComment = (comment) =>
-  comment && [comment.shortText, comment.text].filter(d => d).join('<br/>');
+  comment && [...breakText(comment.shortText), ...breakText(comment.text)]
+            .filter(d => d.trim().length > 0).join('<br/>');
 
 const testResults = (title, results) => results ? [
   h5(title, {class: 'test-result-title'}),


### PR DESCRIPTION
Window refers to WindowCore and vice-versa for the relevant containers.
Improved the rendering of commends so that breaking up a comment with a double new-line works (previously it was merged into a single line).