### PR TITLE
Use code highlighter in jekyll to highlight and colour-code javascript examples

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -8,7 +8,6 @@
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/highlight.js/9.11.0/styles/default.min.css">

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -69,10 +69,24 @@ br {
   padding: 10px 10px;
   margin: 5px 0;
   font-weight: 500;
+  font-size: 90%;
 }
 
 .code, pre {
   width: 100%;
+}
+pre .hljs {
+  background-color: transparent;
+  padding: 0;
+}
+pre .hljs .nx {
+  color: #5A5886;
+}
+pre .hljs .hljs-built_in {
+  color: #A0A039;
+}
+pre .hljs .hljs-comment {
+  color: #39A000;
 }
 
 .method {

--- a/packages/api-specification/transform-type-info.js
+++ b/packages/api-specification/transform-type-info.js
@@ -150,7 +150,8 @@ const breakText = (text) => {
 };
 
 const formatComment = (comment) =>
-  comment && [breakText(comment.shortText), breakText(comment.text)];
+  comment && [breakText(comment.shortText), breakText(comment.text)]
+        .filter(t => t).join('<br />');
 
 const testResults = (title, results) => results ? [
   h5(title, {class: 'test-result-title'}),

--- a/packages/api-specification/transform-type-info.js
+++ b/packages/api-specification/transform-type-info.js
@@ -125,7 +125,7 @@ const breakText = (text) => {
   if (text) {
     let formattedText = '';
     let index = 0;
-    while(index < text.length) {
+    while (index < text.length) {
       const codeStart = text.indexOf('<pre>', index);
       const codeEnd = (codeStart !== -1) ? text.indexOf('</pre>', codeStart + 5) : -1;
 


### PR DESCRIPTION
![highlight-code](https://user-images.githubusercontent.com/8255295/30968252-95e58c50-a456-11e7-826c-54f8f312db84.png)
