### PR TITLE
Add script for publishing packages

### DIFF
--- a/deploy-script.ps1
+++ b/deploy-script.ps1
@@ -1,20 +1,25 @@
 IF ($env:APPVEYOR_REPO_BRANCH -eq "master" -And (-Not (Test-Path Env:\APPVEYOR_PULL_REQUEST_NUMBER))) {
-  Write-Host "Publishing docs to gh-pages"
+  Write-Host "Configuring git in preparation to push docs"
   git config --global credential.helper store
   Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:access_token):x-oauth-basic@github.com`n"
   git config --global user.email $env:github_email
   git config --global user.name "ColinEberhardt"
+
+  Write-Host "Creating commit of docs folder"
   git add -f docs
   git commit -m "Update gh-pages: $env:APPVEYOR_REPO_COMMIT_MESSAGE"
   git subtree split --prefix docs -b gh-pages
+  Write-Host "Publishing docs to gh-pages branch"
   git push -f origin gh-pages:gh-pages
+
   IF ($LASTEXITCODE -ne "0") {
-    Write-Warning -Message 'Deploy Failed'
+    Write-Warning -Message "Deploy of docs to github failed"
   }
 }
 Else {
   Write-Host "Not on branch 'master', not publishing docs"
 }
 
-# Fail if the tests failed
+# Fail the build if the tests failed.
+# Documentation has already been published if appropriate, however.
 exit [Environment]::GetEnvironmentVariable("TestResult", "User")

--- a/release-script.ps1
+++ b/release-script.ps1
@@ -1,0 +1,37 @@
+IF ($env:APPVEYOR_REPO_BRANCH -eq "release" -And (-Not (Test-Path Env:\APPVEYOR_PULL_REQUEST_NUMBER))) {
+
+    IF(-Not $env:npm_release_token) {
+        Write-Warning "No npm token configured: unable to publish to npm";
+        # Return error code 203: "The system could not find the environment option that was entered."
+        exit 203;
+    }
+
+    Write-Host "Creating .npmrc file with auth token"
+    "//registry.npmjs.org/:_authToken=${$env:npm_release_token}" |
+        Out-File (Join-Path $ENV:APPVEYOR_BUILD_FOLDER ".npmrc") -Encoding UTF8
+
+    $originalLocation = Get-Location;
+
+    $PackagesToPublish = Get-ChildItem -Path "packages\*\*" -Filter "package.json" |
+        Where-Object {
+            $_ |
+                Get-Content -Raw |
+                ConvertFrom-Json|
+                Where-Object -Property "private" -ne True
+            };
+
+    Write-Host "Found the following non-private packages to publish:";
+    $PackagesToPublish |
+        Select-Object FullName |
+        Format-Table;
+
+    $PackagesToPublish |
+        ForEach-Object {
+            Set-Location $_.DirectoryName;
+
+            Write-Host "Publishing $_";
+            Invoke-Expression "npm publish";
+        }
+
+    Set-Location $originalLocation;
+}


### PR DESCRIPTION
Script for releasing via Appveyor.

- Will only trigger from `release` branch`.
- Requires `npm_release_token` environment variable set.
- Assumes that a build has taken place already.
- Performs `npm publish` for all non-private packages it can find under `packages\`.

Associated with #347