### PR TITLE
Test setup to handle OpenFin additional window behaviour

### DIFF
--- a/packages/api-tests/test/messaging.spec.js
+++ b/packages/api-tests/test/messaging.spec.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const testContainer = process.env.MOCHA_CONTAINER;
 const setup = require(`./${testContainer}-test-setup`);
 const {
+  initialiseWindows,
   executeAsyncJavascript,
   selectWindow,
   openNewWindow,
@@ -25,8 +26,9 @@ describe('Messaging API', function(done) {
 
   beforeEach(() => {
     app = setup(timeout);
-
-    return app.start();
+    return app.start().then(
+      () => initialiseWindows(app.client)
+    );
   });
 
   afterEach(() => {

--- a/packages/api-tests/test/test-helpers.js
+++ b/packages/api-tests/test/test-helpers.js
@@ -4,8 +4,13 @@ const executeAsyncJavascript = (client, script, ...args) => {
   return client.executeAsync(script, ...args);
 };
 
+// In OpenFin, an extra hidden window gets created that interferes
+// with tests that counts windows or selects windows by index. This
+// initialisation gets the added window handles, so they can be
+// excluded later
 let addedHandles = [];
 const initialiseWindows = (client) => {
+  // Script to wait for app.ready()
   const script = (callback) => {
     if (window.ssf) {
       ssf.app.ready().then(() => {
@@ -20,6 +25,8 @@ const initialiseWindows = (client) => {
   return executeAsyncJavascript(client, script)
       .then(() => client.windowHandles())
       .then(handles => {
+        // The first one is the real main window, and we want
+        // to exclude the rest
         addedHandles = handles.value.splice(1);
       });
 };

--- a/packages/api-tests/test/window.core.spec.js
+++ b/packages/api-tests/test/window.core.spec.js
@@ -29,7 +29,7 @@ const setupWindowSteps = (windowOptions) => [
 
 const closeWindowSteps = () => [
   () => callAsyncWindowMethod('close'),
-  () => app.client.pause(100)
+  () => app.client.pause(100) // Allow time for asynchronously closing child windows
 ];
 
 const retrieveWebUrl = () => {

--- a/packages/api-tests/test/window.spec.js
+++ b/packages/api-tests/test/window.spec.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const testContainer = process.env.MOCHA_CONTAINER;
 const setup = require(`./${testContainer}-test-setup`);
 const {
+  initialiseWindows,
   executeAsyncJavascript,
   selectWindow,
   openNewWindow,
@@ -51,7 +52,9 @@ if (process.env.MOCHA_CONTAINER !== 'browser') {
 
     beforeEach(() => {
       app = setup(timeout);
-      return app.start();
+      return app.start().then(
+        () => initialiseWindows(app.client)
+      );
     });
 
     afterEach(function() {


### PR DESCRIPTION
Get the window handles that are created as part of initialisation, so that they can be excluded from the tests

Also allow a small delay when closing windows, to ensure it has a chance to close any related child windows